### PR TITLE
fix: pin clickhouse image tag

### DIFF
--- a/charts/hdx-oss-v2/templates/app-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/app-deployment.yaml
@@ -23,7 +23,7 @@ spec:
           command: ['sh', '-c', 'until nc -z {{ include "hdx-oss.fullname" . }}-mongodb {{ .Values.mongodb.port }}; do echo waiting for mongodb; sleep 2; done;']
       containers:
         - name: app
-          image: "{{ .Values.images.hdx.repository }}:{{ .Values.images.hdx.tag }}"
+          image: "{{ .Values.hyperdx.image }}"
           ports:
             - name: app-port
               containerPort: {{ .Values.hyperdx.appPort }}
@@ -53,7 +53,7 @@ spec:
       name: app
   selector:
     {{- include "hdx-oss.selectorLabels" . | nindent 4 }}
-    app: app 
+    app: app
 ---
 apiVersion: networking.k8s.io/v1
 kind: Ingress

--- a/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: clickhouse
-          image: "{{ .Values.images.clickhouse.repository }}:{{ .Values.images.clickhouse.tag }}"
+          image: "{{ .Values.clickhouse.image }}"
           ports:
             - containerPort: {{ .Values.clickhouse.port }}
             - containerPort: {{ .Values.clickhouse.nativePort }}
@@ -66,7 +66,7 @@ spec:
       name: native
   selector:
     {{- include "hdx-oss.selectorLabels" . | nindent 4 }}
-    app: clickhouse 
+    app: clickhouse
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/charts/hdx-oss-v2/templates/cronjobs/task-checkAlerts.yaml
+++ b/charts/hdx-oss-v2/templates/cronjobs/task-checkAlerts.yaml
@@ -20,7 +20,7 @@ spec:
           restartPolicy: OnFailure
           containers:
             - name: task
-              image: "{{ .Values.images.hdx.repository }}:{{ .Values.images.hdx.tag | default .Chart.AppVersion }}"
+              image: "{{ .Values.hyperdx.image }}"
               command: ["node", "/app/api/build/tasks/index.js", "check-alerts"]
               envFrom:
                 - configMapRef:

--- a/charts/hdx-oss-v2/templates/mongodb-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/mongodb-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: mongodb
-          image: "{{ .Values.images.mongodb.repository }}:{{ .Values.images.mongodb.tag }}"
+          image: "{{ .Values.mongodb.image }}"
           ports:
             - containerPort: {{ .Values.mongodb.port }}
           volumeMounts:
@@ -42,4 +42,4 @@ spec:
       targetPort: {{ .Values.mongodb.port }}
   selector:
     {{- include "hdx-oss.selectorLabels" . | nindent 4 }}
-    app: mongodb 
+    app: mongodb

--- a/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
         - name: otel-collector
-          image: "{{ .Values.images.otelCollector.repository }}:{{ .Values.images.otelCollector.tag }}"
+          image: "{{ .Values.otel.image }}"
           ports:
             - containerPort: {{ .Values.otel.port }}
             - containerPort: {{ .Values.otel.nativePort }}
@@ -62,5 +62,5 @@ spec:
       name: metrics
   selector:
     {{- include "hdx-oss.selectorLabels" . | nindent 4 }}
-    app: otel-collector 
+    app: otel-collector
 {{- end }}

--- a/charts/hdx-oss-v2/templates/redis-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/redis-deployment.yaml
@@ -19,7 +19,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: "{{ .Values.images.redis.repository }}:{{ .Values.images.redis.tag }}"
+          image: "{{ .Values.redis.image }}"
           ports:
             - containerPort: {{ .Values.redis.port }}
           volumeMounts:
@@ -42,4 +42,4 @@ spec:
       targetPort: {{ .Values.redis.port }}
   selector:
     {{- include "hdx-oss.selectorLabels" . | nindent 4 }}
-    app: redis 
+    app: redis

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -3,6 +3,7 @@ global:
   imagePullSecrets: []
 
 hyperdx:
+  image: "hyperdx/hyperdx:2-beta"
   apiKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   apiPort: 8000
   appPort: 3000
@@ -20,12 +21,15 @@ hyperdx:
       secretName: "hyperdx-tls"
 
 mongodb:
+  image: "mongo:5.0.14-focal"
   port: 27017
 
 redis:
+  image: "redis:7.0.11-alpine"
   port: 6379
 
 clickhouse:
+  image: "clickhouse/clickhouse-server:24-alpine"
   port: 8123
   nativePort: 9000
   enabled: true
@@ -39,29 +43,13 @@ clickhouse:
       otelUserPassword: "otelcollectorpass"
 
 otel:
+  image: "hyperdx/hyperdx-otel-collector:2-beta"
   port: 13133
   nativePort: 24225
   grpcPort: 4317
   httpPort: 4318
   healthPort: 8888
   enabled: true
-
-images:
-  hdx:
-    repository: hyperdx/hyperdx
-    tag: 2-beta
-  redis:
-    repository: redis
-    tag: 7.0.11-alpine
-  mongodb:
-    repository: mongo
-    tag: 5.0.14-focal
-  otelCollector:
-    repository: hyperdx/hyperdx-otel-collector
-    tag: 2-beta
-  clickhouse:
-    repository: clickhouse/clickhouse-server
-    tag: head-alpine
 
 persistence:
   redis:


### PR DESCRIPTION
Instead of using head-alpine, this pins the clickhouse database container image to 24-alpine, which is what we've been using in the dev environments.

Ref: HDX-1652