### PR TITLE
Add support for K8s TLS terminated reverse-proxy scenarios

### DIFF
--- a/charts/hdx-oss-v2/templates/configmaps/app-configmap.yaml
+++ b/charts/hdx-oss-v2/templates/configmaps/app-configmap.yaml
@@ -5,16 +5,16 @@ metadata:
   labels:
     {{- include "hdx-oss.labels" . | nindent 4 }}
 data:
-  APP_PORT: {{ .Values.hyperdx.appPort | quote }}
-  API_PORT: {{ .Values.hyperdx.apiPort | quote }}
-  FRONTEND_URL: "{{ .Values.hyperdx.appUrl }}:{{ .Values.hyperdx.appPort }}"
-  HYPERDX_API_PORT: "{{ .Values.hyperdx.apiPort }}"
-  HYPERDX_APP_PORT: "{{ .Values.hyperdx.appPort }}"
-  HYPERDX_APP_URL: "{{ .Values.hyperdx.appUrl }}"
+  APP_PORT: {{ .Values.hyperdx.app.port | quote }}
+  API_PORT: {{ .Values.hyperdx.api.port | quote }}
+  FRONTEND_URL: "{{ .Values.hyperdx.app.url }}{{if .Values.hyperdx.app.appendPort }}:{{ .Values.hyperdx.app.port }}{{ end }}"
+  HYPERDX_API_PORT: "{{ .Values.hyperdx.api.port }}"
+  HYPERDX_APP_PORT: "{{ .Values.hyperdx.app.port }}"
+  HYPERDX_APP_URL: "{{ .Values.hyperdx.app.url }}"
   HYPERDX_LOG_LEVEL: "{{ .Values.hyperdx.logLevel }}"
   MINER_API_URL: "http://{{ include "hdx-oss.fullname" . }}-miner:5123"
   MONGO_URI: "mongodb://{{ include "hdx-oss.fullname" . }}-mongodb:{{ .Values.mongodb.port }}/hyperdx"
-  NEXT_PUBLIC_SERVER_URL: "http://localhost:{{ .Values.hyperdx.apiPort }}"
+  NEXT_PUBLIC_SERVER_URL: "http://localhost:{{ .Values.hyperdx.api.port }}"
   OTEL_SERVICE_NAME: "hdx-oss-api"
   REDIS_URL: "redis://{{ include "hdx-oss.fullname" . }}-redis:{{ .Values.redis.port }}"
   USAGE_STATS_ENABLED: "{{ .Values.hyperdx.usageStatsEnabled | default true }}"

--- a/charts/hdx-oss-v2/templates/cronjobs/task-checkAlerts.yaml
+++ b/charts/hdx-oss-v2/templates/cronjobs/task-checkAlerts.yaml
@@ -29,7 +29,7 @@ spec:
                 - name: NODE_ENV
                   value: "production"
                 - name: OTEL_SERVICE_NAME
-                  value: "hdx-oss-task-check-alerts"
+                  value: "{{ include "hdx-oss.fullname" . }}-alerts"
               resources:
                 {{- toYaml .Values.tasks.checkAlerts.resources | nindent 16 }}
 {{- end }}

--- a/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end -}}
     {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.hyperdx.replicas | default 1 }}
   selector:
     matchLabels:
       {{- include "hdx-oss.selectorLabels" . | nindent 6 }}
@@ -34,24 +34,35 @@ spec:
           command: ['sh', '-c', 'until nc -z {{ include "hdx-oss.fullname" . }}-mongodb {{ .Values.mongodb.port }}; do echo waiting for mongodb; sleep 2; done;']
       containers:
         - name: app
-          image: "{{ .Values.images.hdx.repository }}:{{ .Values.images.hdx.tag }}"
+          image: "{{ .Values.hyperdx.image }}"
           securityContext:
+            allowPrivilegeEscalation: {{ .Values.hyperdx.securityContext.allowPrivilegeEscalation | default false }}
+            appArmorProfile:
+              type: {{ .Values.hyperdx.securityContext.appArmorProfile.type | default "RuntimeDefault" }}
             capabilities:
-              add: ["NET_ADMIN", "NET_BIND_SERVICE"]
+              add: {{ .Values.hyperdx.securityContext.capabilities.add | default "[]" }}
+              drop: {{ .Values.hyperdx.securityContext.capabilities.drop | default "[]" }}
+            privileged: {{ .Values.hyperdx.securityContext.privileged | default false }}
+            readOnlyRootFilesystem: {{ .Values.hyperdx.securityContext.readOnlyRootFilesystem | default false }}
+            runAsGroup: {{ .Values.hyperdx.securityContext.runAsGroup | default 0 }}
+            runAsUser: {{ .Values.hyperdx.securityContext.runAsUser | default 0 }}
+            runAsNonRoot: {{ .Values.hyperdx.securityContext.runAsNonRoot | default false }}
           ports:
             - name: app-port
               containerPort: {{ .Values.hyperdx.app.port }}
             - name: api-port
-              containerPort: {{ .Values.hyperdx.apiPort }}
+              containerPort: {{ .Values.hyperdx.api.port }}
           envFrom:
             - configMapRef:
                 name: {{ include "hdx-oss.fullname" . }}-app-config
           env:
+            {{- if .Values.hyperd.api.generateKeySecret}}
             - name: HYPERDX_API_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{ include "hdx-oss.fullname" . }}-app-secrets
                   key: api-key
+            {{- end }}
             {{- with .Values.hyperdx.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- end -}}
     {{- end }}
 spec:
-  replicas: {{ .Values.hyperdx.replicas | default 1 }}
+  replicas: 1
   selector:
     matchLabels:
       {{- include "hdx-oss.selectorLabels" . | nindent 6 }}
@@ -34,10 +34,13 @@ spec:
           command: ['sh', '-c', 'until nc -z {{ include "hdx-oss.fullname" . }}-mongodb {{ .Values.mongodb.port }}; do echo waiting for mongodb; sleep 2; done;']
       containers:
         - name: app
-          image: "{{ .Values.hyperdx.image }}"
+          image: "{{ .Values.images.hdx.repository }}:{{ .Values.images.hdx.tag }}"
+          securityContext:
+            capabilities:
+              add: ["NET_ADMIN", "NET_BIND_SERVICE"]
           ports:
             - name: app-port
-              containerPort: {{ .Values.hyperdx.appPort }}
+              containerPort: {{ .Values.hyperdx.app.port }}
             - name: api-port
               containerPort: {{ .Values.hyperdx.apiPort }}
           envFrom:

--- a/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
@@ -56,7 +56,7 @@ spec:
             - configMapRef:
                 name: {{ include "hdx-oss.fullname" . }}-app-config
           env:
-            {{- if .Values.hyperd.api.generateKeySecret}}
+            {{- if .Values.hyperdx.api.generateKeySecret}}
             - name: HYPERDX_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/hdx-oss-v2/templates/hyperdx-service.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-service.yaml
@@ -10,6 +10,9 @@ spec:
     - port: {{ .Values.hyperdx.app.port }}
       targetPort: {{ .Values.hyperdx.app.port }}
       name: app
+    - port: {{ .Values.hyperdx.api.port }}
+      targetPort: {{ .Values.hyperdx.api.port }}
+      name: api
   selector:
     {{- include "hdx-oss.selectorLabels" . | nindent 4 }}
     app: {{ include "hdx-oss.fullname" . }} 

--- a/charts/hdx-oss-v2/templates/hyperdx-service.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-service.yaml
@@ -7,8 +7,8 @@ metadata:
 spec:
   type: LoadBalancer
   ports:
-    - port: {{ .Values.hyperdx.appPort }}
-      targetPort: {{ .Values.hyperdx.appPort }}
+    - port: {{ .Values.hyperdx.app.port }}
+      targetPort: {{ .Values.hyperdx.app.port }}
       name: app
   selector:
     {{- include "hdx-oss.selectorLabels" . | nindent 4 }}

--- a/charts/hdx-oss-v2/templates/secrets.yaml
+++ b/charts/hdx-oss-v2/templates/secrets.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.hyperdx.api.generateKeySecret}}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -6,7 +7,8 @@ metadata:
     {{- include "hdx-oss.labels" . | nindent 4 }}
 type: Opaque
 data:
-  api-key: {{ "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" | b64enc }}
+  api-key: {{ .Values.hyperdx.api.key | b64enc }}
+{{- end }}
 {{- if .Values.clickhouse.enabled }}
 ---
 apiVersion: v1

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -6,8 +6,10 @@ hyperdx:
   image: "hyperdx/hyperdx:2-beta"
   apiKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   apiPort: 8000
-  appPort: 3000
-  appUrl: "http://localhost"
+  app:
+    port: 3000
+    url: "http://localhost"
+    appendPort: false  # Set to true if you want to append the port to the URL in generated links
   logLevel: "info"
   usageStatsEnabled: true
   annotations: {}

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -4,13 +4,27 @@ global:
 
 hyperdx:
   image: "hyperdx/hyperdx:2-beta"
-  apiKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-  apiPort: 8000
+  api:
+    key: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+    port: 8000
+    generateKeySecret: true # disable to manually create the secret
   app:
     port: 3000
     url: "http://localhost"
     appendPort: false  # Set to true if you want to append the port to the URL in generated links
   logLevel: "info"
+  securityContext:
+    allowPrivilegeEscalation:
+    appArmorProfile:
+      type: "RuntimeDefault" # Set to "RuntimeDefault" for AppArmor support, can also use "Unconfined"
+    capabilities:
+      add: [] # add: ["NET_ADMIN", "NET_BIND_SERVICE"] for reverse proxy support
+      drop: []
+    privileged: false
+    readOnlyRootFilesystem: false
+    runAsGroup: 0
+    runAsUser: 0
+    runAsNonRoot: false
   usageStatsEnabled: true
   annotations: {}
     # myAnnotation: "myValue"


### PR DESCRIPTION
The previous configuration required that you append the application port to all urls. This modification allows us to support TLS terminated reverse proxy scenarios. (ie- Istio, etc)