### PR TITLE
feat: Support custom clickhouse domain for otel collector

### DIFF
--- a/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
@@ -29,7 +29,7 @@ spec:
             - containerPort: {{ .Values.otel.healthPort }}
           env:
             - name: CLICKHOUSE_SERVER_ENDPOINT
-              value: "{{ include "hdx-oss.fullname" . }}-clickhouse:{{ .Values.clickhouse.nativePort }}"
+              value: "{{ .Values.otel.clickhouseEndpoint | default (printf "%s-clickhouse:%v" (include "hdx-oss.fullname" .) .Values.clickhouse.nativePort) }}"
             - name: HYPERDX_LOG_LEVEL
               value: {{ .Values.hyperdx.logLevel }}
             - name: CLICKHOUSE_USER

--- a/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
@@ -28,8 +28,8 @@ spec:
             - containerPort: {{ .Values.otel.httpPort }}
             - containerPort: {{ .Values.otel.healthPort }}
           env:
-            - name: CLICKHOUSE_SERVER_ENDPOINT
-              value: "{{ .Values.otel.clickhouseEndpoint | default (printf "%s-clickhouse:%v" (include "hdx-oss.fullname" .) .Values.clickhouse.nativePort) }}"
+            - name: CLICKHOUSE_ENDPOINT
+              value: "{{ .Values.otel.clickhouseEndpoint | default (printf "tcp://%s-clickhouse:%v?dial_timeout=10s" (include "hdx-oss.fullname" .) .Values.clickhouse.nativePort) }}"
             - name: HYPERDX_LOG_LEVEL
               value: {{ .Values.hyperdx.logLevel }}
             - name: CLICKHOUSE_USER

--- a/charts/hdx-oss-v2/tests/__snapshot__/otel-collector-disabled_test.yaml.snap
+++ b/charts/hdx-oss-v2/tests/__snapshot__/otel-collector-disabled_test.yaml.snap
@@ -27,7 +27,7 @@ should render OTEL collector with custom ports:
         spec:
           containers:
             - env:
-                - name: CLICKHOUSE_SERVER_ENDPOINT
+                - name: CLICKHOUSE_ENDPOINT
                   value: RELEASE-NAME-hdx-oss-v2-clickhouse:9000
                 - name: HYPERDX_LOG_LEVEL
                   value: info

--- a/charts/hdx-oss-v2/tests/otel-collector-custom-clickhouse_test.yaml
+++ b/charts/hdx-oss-v2/tests/otel-collector-custom-clickhouse_test.yaml
@@ -13,11 +13,11 @@ tests:
       - documentIndex: 0
         equal:
           path: spec.template.spec.containers[0].env[0].name
-          value: CLICKHOUSE_SERVER_ENDPOINT
+          value: CLICKHOUSE_ENDPOINT
       - documentIndex: 0
         matchRegex:
           path: spec.template.spec.containers[0].env[0].value
-          pattern: ".*-clickhouse:[0-9]+"
+          pattern: "tcp://.*-clickhouse:[0-9]+\\?dial_timeout=10s"
 
   - it: should use custom Clickhouse endpoint when specified
     set:
@@ -31,7 +31,7 @@ tests:
       - documentIndex: 0
         equal:
           path: spec.template.spec.containers[0].env[0].name
-          value: CLICKHOUSE_SERVER_ENDPOINT
+          value: CLICKHOUSE_ENDPOINT
       - documentIndex: 0
         equal:
           path: spec.template.spec.containers[0].env[0].value

--- a/charts/hdx-oss-v2/tests/otel-collector-custom-clickhouse_test.yaml
+++ b/charts/hdx-oss-v2/tests/otel-collector-custom-clickhouse_test.yaml
@@ -1,0 +1,38 @@
+suite: test OTEL collector with custom clickhouse endpoint
+templates:
+  - otel-collector-deployment.yaml
+tests:
+  - it: should use default Clickhouse endpoint when not specified
+    set:
+      otel:
+        enabled: true
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: CLICKHOUSE_SERVER_ENDPOINT
+      - documentIndex: 0
+        matchRegex:
+          path: spec.template.spec.containers[0].env[0].value
+          pattern: ".*-clickhouse:[0-9]+"
+
+  - it: should use custom Clickhouse endpoint when specified
+    set:
+      otel:
+        enabled: true
+        clickhouseEndpoint: "my-custom-clickhouse:9000"
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: CLICKHOUSE_SERVER_ENDPOINT
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "my-custom-clickhouse:9000"

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -60,8 +60,8 @@ otel:
   httpPort: 4318
   healthPort: 8888
   enabled: true
-  # Specify a custom Clickhouse endpoint if not using the built-in Clickhouse
-  # clickhouseEndpoint: "my-external-clickhouse:9000"
+  # Clickhouse endpoint - defaults to built-in Clickhouse service
+  clickhouseEndpoint: ""
 
 persistence:
   mongodb:

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -60,6 +60,8 @@ otel:
   httpPort: 4318
   healthPort: 8888
   enabled: true
+  # Specify a custom Clickhouse endpoint if not using the built-in Clickhouse
+  # clickhouseEndpoint: "my-external-clickhouse:9000"
 
 persistence:
   mongodb:


### PR DESCRIPTION
* Adds setting in values.yml that allows users to specify a custom clickhouse domain for the otel collector instead of forcing them to use the clickhouse deployment in the chart.
* Adds unit tests

Ref: HDX-1760