### PR TITLE
feat: Optimize experience for out of the box installs

### DIFF
--- a/charts/hdx-oss-v2/data/config.xml
+++ b/charts/hdx-oss-v2/data/config.xml
@@ -27,6 +27,18 @@
     <timezone>UTC</timezone>
     <mlock_executable>false</mlock_executable>
 
+    {{- if .Values.clickhouse.prometheus.enabled }}
+    <!-- Prometheus exporter -->
+    <prometheus>
+        <endpoint>{{ .Values.clickhouse.prometheus.endpoint }}</endpoint>
+        <port>{{ .Values.clickhouse.prometheus.port }}</port>
+        <metrics>true</metrics>
+        <events>true</events>
+        <asynchronous_metrics>true</asynchronous_metrics>
+        <errors>true</errors>
+    </prometheus>
+    {{- end }}
+
     <!-- Query log. Used only for queries with setting log_queries = 1. -->
     <query_log>
         <database>system</database>

--- a/charts/hdx-oss-v2/data/users.xml
+++ b/charts/hdx-oss-v2/data/users.xml
@@ -25,7 +25,7 @@
         <app>
             <password>{{ .Values.clickhouse.config.users.appUserPassword }}</password>
             <networks>
-                <ip>10.0.0.0/8</ip>     <!-- Kubernetes cluster IP range -->
+                <ip>{{ .Values.clickhouse.config.clusterCidr }}</ip>     <!-- Kubernetes cluster IP range -->
                 <host_regexp>.*\.svc\.cluster\.local$</host_regexp>
             </networks>
             <profile>readonly</profile>
@@ -39,12 +39,13 @@
         <otelcollector>
             <password>{{ .Values.clickhouse.config.users.otelUserPassword }}</password>
             <networks>
+                <ip>{{ .Values.clickhouse.config.clusterCidr }}</ip>     <!-- Kubernetes cluster IP range -->
                 <host_regexp>.*\.svc\.cluster\.local$</host_regexp>
             </networks>
             <profile>default</profile>
             <quota>default</quota>
             <grants>
-                <query>GRANT SELECT,INSERT,SHOW ON default.*</query>
+                <query>GRANT SELECT,INSERT,CREATE,SHOW ON default.*</query>
             </grants>
         </otelcollector>
     </users>

--- a/charts/hdx-oss-v2/data/users.xml
+++ b/charts/hdx-oss-v2/data/users.xml
@@ -25,7 +25,13 @@
         <app>
             <password>{{ .Values.clickhouse.config.users.appUserPassword }}</password>
             <networks>
-                <ip>{{ .Values.clickhouse.config.clusterCidr }}</ip>     <!-- Kubernetes cluster IP range -->
+                {{- if .Values.clickhouse.config.clusterCidrs }}
+                {{- range .Values.clickhouse.config.clusterCidrs }}
+                <ip>{{ . }}</ip>
+                {{- end }}
+                {{- else }}
+                <ip>10.0.0.0/8</ip>  <!-- Default fallback -->
+                {{- end }}
                 <host_regexp>.*\.svc\.cluster\.local$</host_regexp>
             </networks>
             <profile>readonly</profile>
@@ -39,7 +45,13 @@
         <otelcollector>
             <password>{{ .Values.clickhouse.config.users.otelUserPassword }}</password>
             <networks>
-                <ip>{{ .Values.clickhouse.config.clusterCidr }}</ip>     <!-- Kubernetes cluster IP range -->
+                {{- if .Values.clickhouse.config.clusterCidrs }}
+                {{- range .Values.clickhouse.config.clusterCidrs }}
+                <ip>{{ . }}</ip>
+                {{- end }}
+                {{- else }}
+                <ip>10.0.0.0/8</ip>  <!-- Default fallback -->
+                {{- end }}
                 <host_regexp>.*\.svc\.cluster\.local$</host_regexp>
             </networks>
             <profile>default</profile>

--- a/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
@@ -64,6 +64,11 @@ spec:
     - port: {{ .Values.clickhouse.nativePort }}
       targetPort: {{ .Values.clickhouse.nativePort }}
       name: native
+    {{- if .Values.clickhouse.prometheus.enabled }}
+    - port: {{ .Values.clickhouse.prometheus.port }}
+      targetPort: {{ .Values.clickhouse.prometheus.port }}
+      name: prometheus
+    {{- end }}
   selector:
     {{- include "hdx-oss.selectorLabels" . | nindent 4 }}
     app: clickhouse

--- a/charts/hdx-oss-v2/templates/configmaps/app-configmap.yaml
+++ b/charts/hdx-oss-v2/templates/configmaps/app-configmap.yaml
@@ -19,3 +19,4 @@ data:
   USAGE_STATS_ENABLED: "{{ .Values.hyperdx.usageStatsEnabled | default true }}"
   CRON_IN_APP_DISABLED: "{{ .Values.tasks.enabled | default false }}"
   OPAMP_PORT: "{{ .Values.hyperdx.opampPort }}"
+  OTEL_EXPORTER_OTLP_ENDPOINT: "{{ tpl .Values.hyperdx.otelExporterEndpoint . }}"

--- a/charts/hdx-oss-v2/templates/configmaps/app-configmap.yaml
+++ b/charts/hdx-oss-v2/templates/configmaps/app-configmap.yaml
@@ -18,3 +18,4 @@ data:
   OTEL_SERVICE_NAME: "hdx-oss-api"
   USAGE_STATS_ENABLED: "{{ .Values.hyperdx.usageStatsEnabled | default true }}"
   CRON_IN_APP_DISABLED: "{{ .Values.tasks.enabled | default false }}"
+  OPAMP_PORT: "{{ .Values.hyperdx.opampPort }}"

--- a/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
@@ -49,6 +49,14 @@ spec:
                 secretKeyRef:
                   name: {{ include "hdx-oss.fullname" . }}-app-secrets
                   key: api-key
+            {{- if .Values.hyperdx.defaultConnections }}
+            - name: DEFAULT_CONNECTIONS
+              value: {{ tpl .Values.hyperdx.defaultConnections . | quote }}
+            {{- end }}
+            {{- if .Values.hyperdx.defaultSources }}
+            - name: DEFAULT_SOURCES
+              value: {{ tpl .Values.hyperdx.defaultSources . | quote }}
+            {{- end }}
             {{- with .Values.hyperdx.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
@@ -32,8 +32,17 @@ spec:
               value: "{{ .Values.otel.clickhouseEndpoint | default (printf "tcp://%s-clickhouse:%v?dial_timeout=10s" (include "hdx-oss.fullname" .) .Values.clickhouse.nativePort) }}"
             - name: CLICKHOUSE_SERVER_ENDPOINT
               value: "{{ .Values.otel.clickhouseEndpoint | default (printf "%s-clickhouse:%v" (include "hdx-oss.fullname" .) .Values.clickhouse.nativePort) }}"
+            {{- if .Values.clickhouse.prometheus.enabled }}
+            - name: CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT
+              value: "{{ .Values.otel.clickhousePrometheusEndpoint | default (printf "%s-clickhouse:%v" (include "hdx-oss.fullname" .) .Values.clickhouse.prometheus.port ) }}"
+            {{- end }}
             - name: HYPERDX_LOG_LEVEL
               value: {{ .Values.hyperdx.logLevel }}
+            - name: HYPERDX_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hdx-oss.fullname" . }}-app-secrets
+                  key: api-key
             - name: CLICKHOUSE_USER
               value: "otelcollector"
             - name: CLICKHOUSE_PASSWORD

--- a/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
@@ -30,10 +30,12 @@ spec:
           env:
             - name: CLICKHOUSE_ENDPOINT
               value: "{{ .Values.otel.clickhouseEndpoint | default (printf "tcp://%s-clickhouse:%v?dial_timeout=10s" (include "hdx-oss.fullname" .) .Values.clickhouse.nativePort) }}"
+            - name: CLICKHOUSE_SERVER_ENDPOINT
+              value: "{{ .Values.otel.clickhouseEndpoint | default (printf "%s-clickhouse:%v" (include "hdx-oss.fullname" .) .Values.clickhouse.nativePort) }}"
             - name: HYPERDX_LOG_LEVEL
               value: {{ .Values.hyperdx.logLevel }}
             - name: CLICKHOUSE_USER
-              value: {{ .Values.clickhouse.config.users.otelUser }}
+              value: "otelcollector"
             - name: CLICKHOUSE_PASSWORD
               value: {{ .Values.clickhouse.config.users.otelUserPassword }}
 ---

--- a/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
@@ -36,6 +36,8 @@ spec:
             - name: CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT
               value: "{{ .Values.otel.clickhousePrometheusEndpoint | default (printf "%s-clickhouse:%v" (include "hdx-oss.fullname" .) .Values.clickhouse.prometheus.port ) }}"
             {{- end }}
+            - name: OPAMP_SERVER_URL
+              value: {{ .Values.otel.opampServerUrl | default (printf "%s-app:%v" (include "hdx-oss.fullname" .) .Values.hyperdx.opampPort ) }}
             - name: HYPERDX_LOG_LEVEL
               value: {{ .Values.hyperdx.logLevel }}
             - name: HYPERDX_API_KEY

--- a/charts/hdx-oss-v2/templates/secrets.yaml
+++ b/charts/hdx-oss-v2/templates/secrets.yaml
@@ -6,7 +6,7 @@ metadata:
     {{- include "hdx-oss.labels" . | nindent 4 }}
 type: Opaque
 data:
-  api-key: {{ "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" | b64enc }}
+  api-key: {{ .Values.hyperdx.apiKey | b64enc }}
 {{- if .Values.clickhouse.enabled }}
 ---
 apiVersion: v1

--- a/charts/hdx-oss-v2/tests/clickhouse-users_test.yaml
+++ b/charts/hdx-oss-v2/tests/clickhouse-users_test.yaml
@@ -1,0 +1,121 @@
+suite: Test ClickHouse Users Configuration
+templates:
+  - clickhouse-deployment.yaml
+tests:
+  - it: should render Deployment with users volume mount
+    asserts:
+      - isKind:
+          of: Deployment
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: users
+            mountPath: /etc/clickhouse-server/users.xml
+            subPath: users.xml
+        documentIndex: 0
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: users
+            configMap:
+              name: RELEASE-NAME-hdx-oss-v2-clickhouse-users
+        documentIndex: 0
+
+  - it: should render users ConfigMap with default values
+    asserts:
+      - isKind:
+          of: ConfigMap
+        documentIndex: 3
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-hdx-oss-v2-clickhouse-users
+        documentIndex: 3
+      - isNotEmpty:
+          path: data
+        documentIndex: 3
+
+  - it: should render users ConfigMap with custom clusterCidrs
+    set:
+      clickhouse:
+        config:
+          users:
+            appUserPassword: "customapppass"
+            otelUserPassword: "customotelpass"
+          clusterCidrs:
+            - "10.0.0.0/8"
+            - "172.16.0.0/12"
+            - "192.168.0.0/16"
+    asserts:
+      - isKind:
+          of: ConfigMap
+        documentIndex: 3
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-hdx-oss-v2-clickhouse-users
+        documentIndex: 3
+      - isNotEmpty:
+          path: data
+        documentIndex: 3
+
+  - it: should render users ConfigMap with single clusterCidr
+    set:
+      clickhouse:
+        config:
+          users:
+            appUserPassword: "singleapppass"
+            otelUserPassword: "singleotelpass"
+          clusterCidrs:
+            - "10.244.0.0/16"
+    asserts:
+      - isKind:
+          of: ConfigMap
+        documentIndex: 3
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-hdx-oss-v2-clickhouse-users
+        documentIndex: 3
+      - isNotEmpty:
+          path: data
+        documentIndex: 3
+
+  - it: should render users ConfigMap with empty clusterCidrs
+    set:
+      clickhouse:
+        config:
+          users:
+            appUserPassword: "emptyapppass"
+            otelUserPassword: "emptyotelpass"
+          clusterCidrs: []
+    asserts:
+      - isKind:
+          of: ConfigMap
+        documentIndex: 3
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-hdx-oss-v2-clickhouse-users
+        documentIndex: 3
+      - isNotEmpty:
+          path: data
+        documentIndex: 3
+
+  - it: should render users ConfigMap with custom passwords
+    set:
+      clickhouse:
+        config:
+          users:
+            appUserPassword: "mySecretAppPassword"
+            otelUserPassword: "mySecretOtelPassword"
+          clusterCidrs:
+            - "10.0.0.0/8"
+    asserts:
+      - isKind:
+          of: ConfigMap
+        documentIndex: 3
+      - equal:
+          path: metadata.name
+          value: RELEASE-NAME-hdx-oss-v2-clickhouse-users
+        documentIndex: 3
+      - isNotEmpty:
+          path: data
+        documentIndex: 3

--- a/charts/hdx-oss-v2/tests/default-env-vars_test.yaml
+++ b/charts/hdx-oss-v2/tests/default-env-vars_test.yaml
@@ -1,0 +1,132 @@
+suite: Test Default Environment Variables
+templates:
+  - hyperdx-deployment.yaml
+tests:
+  - it: should add DEFAULT_CONNECTIONS env var when configured with secrets
+    set:
+      hyperdx:
+        env:
+          - name: DEFAULT_CONNECTIONS
+            valueFrom:
+              secretKeyRef:
+                name: hyperdx-connections
+                key: connections-json
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEFAULT_CONNECTIONS
+            valueFrom:
+              secretKeyRef:
+                name: hyperdx-connections
+                key: connections-json
+
+  - it: should add DEFAULT_SOURCES env var when configured with plain value
+    set:
+      hyperdx:
+        env:
+          - name: DEFAULT_SOURCES
+            value: '[{"name":"HyperDX Logs","kind":"log","connection":"Local ClickHouse"}]'
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEFAULT_SOURCES
+            value: '[{"name":"HyperDX Logs","kind":"log","connection":"Local ClickHouse"}]'
+
+  - it: should add DEFAULT_SOURCES env var when configured with secrets
+    set:
+      hyperdx:
+        env:
+          - name: DEFAULT_SOURCES
+            valueFrom:
+              secretKeyRef:
+                name: hyperdx-sources
+                key: sources-json
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEFAULT_SOURCES
+            valueFrom:
+              secretKeyRef:
+                name: hyperdx-sources
+                key: sources-json
+
+  - it: should add both DEFAULT_CONNECTIONS and DEFAULT_SOURCES when configured
+    set:
+      hyperdx:
+        env:
+          - name: DEFAULT_CONNECTIONS
+            valueFrom:
+              secretKeyRef:
+                name: hyperdx-connections
+                key: connections-json
+          - name: DEFAULT_SOURCES
+            valueFrom:
+              secretKeyRef:
+                name: hyperdx-sources
+                key: sources-json
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEFAULT_CONNECTIONS
+            valueFrom:
+              secretKeyRef:
+                name: hyperdx-connections
+                key: connections-json
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEFAULT_SOURCES
+            valueFrom:
+              secretKeyRef:
+                name: hyperdx-sources
+                key: sources-json
+
+  - it: should not include DEFAULT_CONNECTIONS or DEFAULT_SOURCES when not configured
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEFAULT_CONNECTIONS
+      - notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEFAULT_SOURCES
+
+  - it: should work with multiline JSON value for DEFAULT_SOURCES
+    set:
+      hyperdx:
+        env:
+          - name: DEFAULT_SOURCES
+            value: |
+              [
+                {
+                  "name": "HyperDX Logs",
+                  "kind": "log",
+                  "connection": "Local ClickHouse",
+                  "from": {
+                    "databaseName": "default",
+                    "tableName": "logs"
+                  }
+                }
+              ]
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: DEFAULT_SOURCES
+            value: |
+              [
+                {
+                  "name": "HyperDX Logs",
+                  "kind": "log",
+                  "connection": "Local ClickHouse",
+                  "from": {
+                    "databaseName": "default",
+                    "tableName": "logs"
+                  }
+                }
+              ]

--- a/charts/hdx-oss-v2/tests/default-env-vars_test.yaml
+++ b/charts/hdx-oss-v2/tests/default-env-vars_test.yaml
@@ -85,12 +85,28 @@ tests:
                 name: hyperdx-sources
                 key: sources-json
 
-  - it: should not include DEFAULT_CONNECTIONS or DEFAULT_SOURCES when not configured
+  - it: should include DEFAULT_CONNECTIONS and DEFAULT_SOURCES by default
+    asserts:
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].env[?(@.name=="DEFAULT_CONNECTIONS")]
+      - isNotEmpty:
+          path: spec.template.spec.containers[0].env[?(@.name=="DEFAULT_SOURCES")]
+
+  - it: should not include DEFAULT_CONNECTIONS when set to empty string
+    set:
+      hyperdx:
+        defaultConnections: ""
     asserts:
       - notContains:
           path: spec.template.spec.containers[0].env
           content:
             name: DEFAULT_CONNECTIONS
+
+  - it: should not include DEFAULT_SOURCES when set to empty string
+    set:
+      hyperdx:
+        defaultSources: ""
+    asserts:
       - notContains:
           path: spec.template.spec.containers[0].env
           content:

--- a/charts/hdx-oss-v2/tests/otel-collector_test.yaml
+++ b/charts/hdx-oss-v2/tests/otel-collector_test.yaml
@@ -28,4 +28,252 @@ tests:
         enabled: false
     asserts:
       - hasDocuments:
-          count: 0 
+          count: 0
+
+  - it: should render environment variables correctly with default values
+    set:
+      otel:
+        enabled: true
+        image: hyperdx/hyperdx-otel-collector:2-beta
+      hyperdx:
+        logLevel: info
+      clickhouse:
+        nativePort: 9000
+        prometheus:
+          enabled: true
+          port: 9363
+          endpoint: "/metrics"
+        config:
+          users:
+            otelUserPassword: test-password
+    release:
+      name: test-release
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_ENDPOINT
+            value: "tcp://test-release-hdx-oss-v2-clickhouse:9000?dial_timeout=10s"
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_SERVER_ENDPOINT
+            value: "test-release-hdx-oss-v2-clickhouse:9000"
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT
+            value: "test-release-hdx-oss-v2-clickhouse:9363"
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HYPERDX_LOG_LEVEL
+            value: info
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_USER
+            value: "otelcollector"
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_PASSWORD
+            value: test-password
+
+  - it: should render environment variables correctly with custom clickhouse endpoint
+    set:
+      otel:
+        enabled: true
+        image: hyperdx/hyperdx-otel-collector:2-beta
+        clickhouseEndpoint: "tcp://custom-clickhouse:9000"
+      hyperdx:
+        logLevel: debug
+      clickhouse:
+        prometheus:
+          enabled: true
+          port: 9363
+          endpoint: "/metrics"
+        config:
+          users:
+            otelUserPassword: custom-password
+    release:
+      name: custom-release
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_ENDPOINT
+            value: "tcp://custom-clickhouse:9000"
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_SERVER_ENDPOINT
+            value: "tcp://custom-clickhouse:9000"
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT
+            value: "custom-release-hdx-oss-v2-clickhouse:9363"
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HYPERDX_LOG_LEVEL
+            value: debug
+
+  - it: should render service ports correctly
+    set:
+      otel:
+        enabled: true
+        port: 13133
+        nativePort: 24225
+        grpcPort: 4317
+        httpPort: 4318
+        healthPort: 8888
+    asserts:
+      - documentIndex: 1
+        isKind:
+          of: Service
+      - documentIndex: 1
+        contains:
+          path: spec.ports
+          content:
+            port: 13133
+            targetPort: 13133
+            name: health
+      - documentIndex: 1
+        contains:
+          path: spec.ports
+          content:
+            port: 24225
+            targetPort: 24225
+            name: fluentd
+      - documentIndex: 1
+        contains:
+          path: spec.ports
+          content:
+            port: 4317
+            targetPort: 4317
+            name: otlp-grpc
+      - documentIndex: 1
+        contains:
+          path: spec.ports
+          content:
+            port: 4318
+            targetPort: 4318
+            name: otlp-http
+      - documentIndex: 1
+        contains:
+          path: spec.ports
+          content:
+            port: 8888
+            targetPort: 8888
+            name: metrics
+
+  - it: should render container ports correctly
+    set:
+      otel:
+        enabled: true
+        port: 13133
+        nativePort: 24225
+        grpcPort: 4317
+        httpPort: 4318
+        healthPort: 8888
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 13133
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 24225
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 4317
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 4318
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].ports
+          content:
+            containerPort: 8888
+
+  - it: should render environment variables with custom prometheus endpoint
+    set:
+      otel:
+        enabled: true
+        image: hyperdx/hyperdx-otel-collector:2-beta
+        clickhousePrometheusEndpoint: "external-clickhouse:8080/custom-metrics"
+      hyperdx:
+        logLevel: info
+      clickhouse:
+        prometheus:
+          enabled: true
+          port: 9363
+          endpoint: "/metrics"
+        config:
+          users:
+            otelUserPassword: test-password
+    release:
+      name: test-release
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT
+            value: "external-clickhouse:8080/custom-metrics"
+
+  - it: should not render prometheus endpoint when disabled
+    set:
+      otel:
+        enabled: true
+        image: hyperdx/hyperdx-otel-collector:2-beta
+      hyperdx:
+        logLevel: info
+      clickhouse:
+        prometheus:
+          enabled: false
+        config:
+          users:
+            otelUserPassword: test-password
+    release:
+      name: test-release
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        notContains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT

--- a/charts/hdx-oss-v2/tests/otel-exporter-endpoint_test.yaml
+++ b/charts/hdx-oss-v2/tests/otel-exporter-endpoint_test.yaml
@@ -1,0 +1,36 @@
+suite: Test OTEL Exporter Endpoint Configuration
+templates:
+  - configmaps/app-configmap.yaml
+tests:
+  - it: should use httpPort (4318) for otelExporterEndpoint by default
+    asserts:
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://RELEASE-NAME-hdx-oss-v2-otel-collector:4318"
+
+  - it: should use custom httpPort when otel.httpPort is overridden
+    set:
+      otel:
+        httpPort: 9999
+    asserts:
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://RELEASE-NAME-hdx-oss-v2-otel-collector:9999"
+
+  - it: should use custom otelExporterEndpoint when explicitly set
+    set:
+      hyperdx:
+        otelExporterEndpoint: "http://custom-otel-collector:4318"
+    asserts:
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_ENDPOINT
+          value: "http://custom-otel-collector:4318"
+
+  - it: should set empty string when otelExporterEndpoint is empty
+    set:
+      hyperdx:
+        otelExporterEndpoint: ""
+    asserts:
+      - equal:
+          path: data.OTEL_EXPORTER_OTLP_ENDPOINT
+          value: ""

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -16,50 +16,125 @@ hyperdx:
   labels: {}
     # myLabel: "myValue"
   env: []
-    # DEFAULT_CONNECTIONS: Configure via external secrets (contains sensitive credentials)
-    # Create your secret first, then reference it:
-    # kubectl create secret generic hyperdx-connections \
-    #   --from-literal=connections-json='[{"name":"Local ClickHouse","host":"clickhouse:8123","username":"default","password":"default"}]'
-    # 
-    # Then reference the secret:
-    # - name: DEFAULT_CONNECTIONS
-    #   valueFrom:
-    #     secretKeyRef:
-    #       name: hyperdx-connections
-    #       key: connections-json
-    
-    # DEFAULT_SOURCES: Configure via external secrets or plain values
-    # For non-sensitive source configurations, you can use plain values:
-    # - name: DEFAULT_SOURCES
-    #   value: |
-    #     [
-    #       {
-    #         "name": "HyperDX Logs",
-    #         "kind": "log",
-    #         "connection": "Local ClickHouse",
-    #         "from": {
-    #           "databaseName": "default",
-    #           "tableName": "logs"
-    #         },
-    #         "timestampValueExpression": "timestamp",
-    #         "displayedTimestampValueExpression": "timestamp",
-    #         "bodyExpression": "body",
-    #         "severityTextExpression": "severity_text",
-    #         "serviceNameExpression": "service_name",
-    #         "resourceAttributesExpression": "resource",
-    #         "traceIdExpression": "trace_id",
-    #         "spanIdExpression": "span_id"
-    #       }
-    #     ]
-    #
-    # Or use secrets for consistency:
-    # - name: DEFAULT_SOURCES
-    #   valueFrom:
-    #     secretKeyRef:
-    #       name: hyperdx-sources  
-    #       key: sources-json
-    # See https://github.com/hyperdxio/hyperdx/blob/v2/packages/api/docs/auto_provision/AUTO_PROVISION.md
-    # for more information on how to configure these values.
+    # Additional environment variables can be configured here
+    # This is preserved for backward compatibility and advanced use cases
+
+  # Default connections and sources (ENABLED BY DEFAULT)
+  # Set to empty string to disable: defaultConnections: ""
+  defaultConnections: |
+    [
+      {
+        "name": "Local ClickHouse",
+        "host": "{{ include "hdx-oss.fullname" . }}-clickhouse",
+        "port": 8123,
+        "username": "app",
+        "password": "{{ .Values.clickhouse.config.users.appUserPassword }}"
+      }
+    ]
+
+  # Set to empty string to disable: defaultSources: ""
+  defaultSources: |
+    [
+      {
+        "from": {
+          "databaseName": "default",
+          "tableName": "otel_logs"
+        },
+        "kind": "log",
+        "timestampValueExpression": "TimestampTime",
+        "name": "Logs",
+        "displayedTimestampValueExpression": "Timestamp",
+        "implicitColumnExpression": "Body",
+        "serviceNameExpression": "ServiceName",
+        "bodyExpression": "Body",
+        "eventAttributesExpression": "LogAttributes",
+        "resourceAttributesExpression": "ResourceAttributes",
+        "defaultTableSelectExpression": "Timestamp,ServiceName,SeverityText,Body",
+        "severityTextExpression": "SeverityText",
+        "traceIdExpression": "TraceId",
+        "spanIdExpression": "SpanId",
+        "connection": "Local ClickHouse",
+        "traceSourceId": "Traces",
+        "sessionSourceId": "Sessions",
+        "metricSourceId": "Metrics"
+      },
+      {
+        "from": {
+          "databaseName": "default",
+          "tableName": "otel_traces"
+        },
+        "kind": "trace",
+        "timestampValueExpression": "Timestamp",
+        "name": "Traces",
+        "displayedTimestampValueExpression": "Timestamp",
+        "implicitColumnExpression": "SpanName",
+        "serviceNameExpression": "ServiceName",
+        "bodyExpression": "SpanName",
+        "eventAttributesExpression": "SpanAttributes",
+        "resourceAttributesExpression": "ResourceAttributes",
+        "defaultTableSelectExpression": "Timestamp,ServiceName,StatusCode,round(Duration/1e6),SpanName",
+        "traceIdExpression": "TraceId",
+        "spanIdExpression": "SpanId",
+        "durationExpression": "Duration",
+        "durationPrecision": 9,
+        "parentSpanIdExpression": "ParentSpanId",
+        "spanNameExpression": "SpanName",
+        "spanKindExpression": "SpanKind",
+        "statusCodeExpression": "StatusCode",
+        "statusMessageExpression": "StatusMessage",
+        "connection": "Local ClickHouse",
+        "logSourceId": "Logs",
+        "sessionSourceId": "Sessions",
+        "metricSourceId": "Metrics"
+      },
+      {
+        "from": {
+          "databaseName": "default",
+          "tableName": ""
+        },
+        "kind": "metric",
+        "timestampValueExpression": "TimeUnix",
+        "name": "Metrics",
+        "resourceAttributesExpression": "ResourceAttributes",
+        "metricTables": {
+          "gauge": "otel_metrics_gauge",
+          "histogram": "otel_metrics_histogram",
+          "sum": "otel_metrics_sum",
+          "_id": "682586a8b1f81924e628e808",
+          "id": "682586a8b1f81924e628e808"
+        },
+        "connection": "Local ClickHouse",
+        "logSourceId": "Logs",
+        "traceSourceId": "Traces",
+        "sessionSourceId": "Sessions"
+      },
+      {
+        "from": {
+          "databaseName": "default",
+          "tableName": "hyperdx_sessions"
+        },
+        "kind": "session",
+        "timestampValueExpression": "TimestampTime",
+        "name": "Sessions",
+        "displayedTimestampValueExpression": "Timestamp",
+        "implicitColumnExpression": "Body",
+        "serviceNameExpression": "ServiceName",
+        "bodyExpression": "Body",
+        "eventAttributesExpression": "LogAttributes",
+        "resourceAttributesExpression": "ResourceAttributes",
+        "defaultTableSelectExpression": "Timestamp,ServiceName,SeverityText,Body",
+        "severityTextExpression": "SeverityText",
+        "traceIdExpression": "TraceId",
+        "spanIdExpression": "SpanId",
+        "connection": "Local ClickHouse",
+        "logSourceId": "Logs",
+        "traceSourceId": "Traces",
+        "metricSourceId": "Metrics"
+      }
+    ]
+  
+  # See https://github.com/hyperdxio/hyperdx/blob/v2/packages/api/docs/auto_provision/AUTO_PROVISION.md
+  # for detailed configuration options
 
   ingress:
     enabled: false
@@ -90,6 +165,9 @@ clickhouse:
     users:
       appUserPassword: "hyperdx"
       otelUserPassword: "otelcollectorpass"
+    # Network CIDR for Kubernetes cluster (adjust for your cluster). Ensures connections are locked down to intra cluster only.
+    # Common values: "10.0.0.0/8" (most k8s), "192.168.0.0/16" (OrbStack), "172.16.0.0/12" (some clouds)
+    clusterCidr: "10.0.0.0/8"
 
 otel:
   image: "hyperdx/hyperdx-otel-collector:2-beta"
@@ -100,7 +178,7 @@ otel:
   healthPort: 8888
   enabled: true
   # Clickhouse endpoint - defaults to built-in Clickhouse service
-  clickhouseEndpoint: ""
+  clickhouseEndpoint:
 
 persistence:
   mongodb:

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -165,9 +165,14 @@ clickhouse:
     users:
       appUserPassword: "hyperdx"
       otelUserPassword: "otelcollectorpass"
-    # Network CIDR for Kubernetes cluster (adjust for your cluster). Ensures connections are locked down to intra cluster only.
-    # Common values: "10.0.0.0/8" (most k8s), "192.168.0.0/16" (OrbStack), "172.16.0.0/12" (some clouds)
-    clusterCidr: "10.0.0.0/8"
+    # Network CIDRs for Kubernetes cluster access control
+    # These CIDRs ensure ClickHouse connections are locked down to intra-cluster only
+    # For PRODUCTION: Remove development CIDRs and keep only your cluster's specific CIDR
+    # For DEVELOPMENT: Multiple common CIDRs are included for convenience
+    clusterCidrs:
+      - "10.0.0.0/8"        # Most Kubernetes clusters (including GKE, EKS, AKS)
+      - "172.16.0.0/12"     # Some cloud providers and Docker Desktop
+      - "192.168.0.0/16"    # OrbStack, Minikube, and local development
 
 otel:
   image: "hyperdx/hyperdx-otel-collector:2-beta"

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -161,6 +161,10 @@ clickhouse:
     enabled: true
     dataSize: 10Gi
     logSize: 5Gi
+  prometheus:
+    enabled: true
+    port: 9363
+    endpoint: "/metrics"
   config:
     users:
       appUserPassword: "hyperdx"
@@ -182,8 +186,14 @@ otel:
   httpPort: 4318
   healthPort: 8888
   enabled: true
-  # Clickhouse endpoint - defaults to built-in Clickhouse service
+  # Clickhouse endpoint - defaults to chart's Clickhouse service. Customize if you want to use a different Clickhouse service.
+  # Leave empty if you want to use the chart's Clickhouse service.
+  # Example: clickhouseEndpoint: "tcp://custom-clickhouse-service:9000"
   clickhouseEndpoint:
+  # Clickhouse Prometheus endpoint - defaults to chart's Clickhouse prometheus service. Customize if you want to use a different Clickhouse prometheus service. 
+  # Leave empty if prometheus is disabled.
+  # Example: clickhousePrometheusEndpoint: "http://custom-clickhouse-service:9363"
+  clickhousePrometheusEndpoint:
 
 persistence:
   mongodb:

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -12,6 +12,8 @@ hyperdx:
   appUrl: "http://localhost"
   logLevel: "info"
   usageStatsEnabled: true
+  # Endpoint to send hyperdx logs/traces/metrics to.Defaults to the chart's otel collector endpoint.
+  otelExporterEndpoint: http://{{ include "hdx-oss.fullname" . }}-otel-collector:{{ .Values.otel.httpPort }}
   annotations: {}
     # myAnnotation: "myValue"
   labels: {}

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -2,6 +2,7 @@ global:
   imageRegistry: ""
   imagePullSecrets: []
   storageClassName: []
+
 hyperdx:
   image: "hyperdx/hyperdx:2-beta"
   apiKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
@@ -15,13 +16,51 @@ hyperdx:
   labels: {}
     # myLabel: "myValue"
   env: []
-    # - name: CLICKHOUSE_USER
-    #   value: abc
-    # - name: test
+    # DEFAULT_CONNECTIONS: Configure via external secrets (contains sensitive credentials)
+    # Create your secret first, then reference it:
+    # kubectl create secret generic hyperdx-connections \
+    #   --from-literal=connections-json='[{"name":"Local ClickHouse","host":"clickhouse:8123","username":"default","password":"default"}]'
+    # 
+    # Then reference the secret:
+    # - name: DEFAULT_CONNECTIONS
     #   valueFrom:
     #     secretKeyRef:
-    #       name: some-secret
-    #       key: some-key
+    #       name: hyperdx-connections
+    #       key: connections-json
+    
+    # DEFAULT_SOURCES: Configure via external secrets or plain values
+    # For non-sensitive source configurations, you can use plain values:
+    # - name: DEFAULT_SOURCES
+    #   value: |
+    #     [
+    #       {
+    #         "name": "HyperDX Logs",
+    #         "kind": "log",
+    #         "connection": "Local ClickHouse",
+    #         "from": {
+    #           "databaseName": "default",
+    #           "tableName": "logs"
+    #         },
+    #         "timestampValueExpression": "timestamp",
+    #         "displayedTimestampValueExpression": "timestamp",
+    #         "bodyExpression": "body",
+    #         "severityTextExpression": "severity_text",
+    #         "serviceNameExpression": "service_name",
+    #         "resourceAttributesExpression": "resource",
+    #         "traceIdExpression": "trace_id",
+    #         "spanIdExpression": "span_id"
+    #       }
+    #     ]
+    #
+    # Or use secrets for consistency:
+    # - name: DEFAULT_SOURCES
+    #   valueFrom:
+    #     secretKeyRef:
+    #       name: hyperdx-sources  
+    #       key: sources-json
+    # See https://github.com/hyperdxio/hyperdx/blob/v2/packages/api/docs/auto_provision/AUTO_PROVISION.md
+    # for more information on how to configure these values.
+
   ingress:
     enabled: false
     host: "localhost"  # Production domain

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -8,6 +8,7 @@ hyperdx:
   apiKey: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
   apiPort: 8000
   appPort: 3000
+  opampPort: 4320
   appUrl: "http://localhost"
   logLevel: "info"
   usageStatsEnabled: true
@@ -25,7 +26,7 @@ hyperdx:
     [
       {
         "name": "Local ClickHouse",
-        "host": "{{ include "hdx-oss.fullname" . }}-clickhouse",
+        "host": "http://{{ include "hdx-oss.fullname" . }}-clickhouse:8123",
         "port": 8123,
         "username": "app",
         "password": "{{ .Values.clickhouse.config.users.appUserPassword }}"
@@ -186,6 +187,10 @@ otel:
   httpPort: 4318
   healthPort: 8888
   enabled: true
+  # Opamp server URL - defaults to the app service. Customize if you want to use a different Opamp server.
+  # Leave empty if you want to use the app service.
+  # Example: opampServerUrl: "http://custom-opamp-server:4320"
+  opampServerUrl:
   # Clickhouse endpoint - defaults to chart's Clickhouse service. Customize if you want to use a different Clickhouse service.
   # Leave empty if you want to use the chart's Clickhouse service.
   # Example: clickhouseEndpoint: "tcp://custom-clickhouse-service:9000"


### PR DESCRIPTION
- Adds documentation for DEFAULT_SOURCES and DEFAULT_CONNECTIONS env vars
- Adds unit test to ensure they are rendered correctly
- Fixes issues for default user experience like:
    * Sets otel_collector url for hyperdx app so the app's logs/traces/metrics are collected
    * Add OPAMP URL to otel config
    * ADD API Key to otel config

After this change, default installs will have a default connection and sources, clickhouse metrics will be recorded, and hyperdx logs/metrics/traces will be sent through the collector, resulting in a UI that is auto configured and has data flowing through.

Ref: HDX-1740