### PR TITLE
fix: Fix OpAMP url, expose ports & chart maintenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,37 @@ ingress:
           pathType: ImplementationSpecific
 ```
 
+## Post-Installation: Configuring Telemetry API Key
+
+After successfully deploying HyperDX, you'll need to configure the API key to enable the app's telemetry data collection:
+
+1. **Access your HyperDX instance** via the configured ingress or service endpoint
+2. **Log into the HyperDX dashboard** and navigate to Team settings to generate or retrieve your API key
+3. **Update your deployment** with the API key using one of the following methods:
+
+### Method 1: Update via Helm upgrade with values file
+
+Add the API key to your `values.yaml`:
+
+```yaml
+hyperdx:
+  apiKey: "your-api-key-here"
+```
+
+Then upgrade your deployment:
+
+```sh
+helm upgrade my-hyperdx hyperdx/hdx-oss-v2 -f values.yaml
+```
+
+### Method 2: Update via Helm upgrade with --set flag
+
+```sh
+helm upgrade my-hyperdx hyperdx/hdx-oss-v2 --set hyperdx.apiKey="your-api-key-here"
+```
+
+**Note:** The chart automatically creates a Kubernetes secret (`<release-name>-app-secrets`) with your API key. No additional secret configuration is needed unless you want to use an external secret.
+
 ## Using Secrets
 
 For handling sensitive data such as API keys or database credentials, use Kubernetes secrets. The HyperDX Helm charts provide default secret files that you can modify and apply to your cluster.

--- a/README.md
+++ b/README.md
@@ -94,6 +94,12 @@ helm upgrade my-hyperdx hyperdx/hdx-oss-v2 -f values.yaml
 helm upgrade my-hyperdx hyperdx/hdx-oss-v2 --set hyperdx.apiKey="your-api-key-here"
 ```
 
+**Important:** After updating the API key, you need to restart the pods to pick up the new configuration:
+
+```sh
+kubectl rollout restart deployment my-hyperdx-hdx-oss-v2-app my-hyperdx-hdx-oss-v2-otel-collector
+```
+
 **Note:** The chart automatically creates a Kubernetes secret (`<release-name>-app-secrets`) with your API key. No additional secret configuration is needed unless you want to use an external secret.
 
 ## Using Secrets

--- a/charts/hdx-oss-v2/templates/claims/persistent-volume-claims.yaml
+++ b/charts/hdx-oss-v2/templates/claims/persistent-volume-claims.yaml
@@ -8,7 +8,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  {{- if .Values.global.storageClass }}
   storageClassName: {{ .Values.global.storageClass }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.persistence.mongodb.size }}

--- a/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
@@ -105,7 +105,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  {{- if .Values.global.storageClass }}
   storageClassName: {{ .Values.global.storageClass }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.clickhouse.persistence.dataSize }}
@@ -119,7 +121,9 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
+  {{- if .Values.global.storageClass }}
   storageClassName: {{ .Values.global.storageClass }}
+  {{- end }}
   resources:
     requests:
       storage: {{ .Values.clickhouse.persistence.logSize }}

--- a/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
@@ -40,6 +40,8 @@ spec:
               containerPort: {{ .Values.hyperdx.appPort }}
             - name: api-port
               containerPort: {{ .Values.hyperdx.apiPort }}
+            - name: opamp-port
+              containerPort: {{ .Values.hyperdx.opampPort }}
           envFrom:
             - configMapRef:
                 name: {{ include "hdx-oss.fullname" . }}-app-config

--- a/charts/hdx-oss-v2/templates/hyperdx-service.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-service.yaml
@@ -10,6 +10,9 @@ spec:
     - port: {{ .Values.hyperdx.appPort }}
       targetPort: {{ .Values.hyperdx.appPort }}
       name: app
+    - port: {{ .Values.hyperdx.opampPort }}
+      targetPort: {{ .Values.hyperdx.opampPort }}
+      name: opamp
   selector:
     {{- include "hdx-oss.selectorLabels" . | nindent 4 }}
     app: {{ include "hdx-oss.fullname" . }} 

--- a/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
@@ -40,6 +40,8 @@ spec:
               value: {{ .Values.otel.opampServerUrl | default (printf "http://%s-app:%v" (include "hdx-oss.fullname" .) .Values.hyperdx.opampPort ) }}
             - name: HYPERDX_LOG_LEVEL
               value: {{ .Values.hyperdx.logLevel }}
+            - name: HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE
+              value: {{ .Values.hyperdx.clickhouseDatabase | default "default" }}
             - name: HYPERDX_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
@@ -37,7 +37,7 @@ spec:
               value: "{{ .Values.otel.clickhousePrometheusEndpoint | default (printf "%s-clickhouse:%v" (include "hdx-oss.fullname" .) .Values.clickhouse.prometheus.port ) }}"
             {{- end }}
             - name: OPAMP_SERVER_URL
-              value: {{ .Values.otel.opampServerUrl | default (printf "%s-app:%v" (include "hdx-oss.fullname" .) .Values.hyperdx.opampPort ) }}
+              value: {{ .Values.otel.opampServerUrl | default (printf "http://%s-app:%v" (include "hdx-oss.fullname" .) .Values.hyperdx.opampPort ) }}
             - name: HYPERDX_LOG_LEVEL
               value: {{ .Values.hyperdx.logLevel }}
             - name: HYPERDX_API_KEY

--- a/charts/hdx-oss-v2/tests/clickhouse-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/clickhouse-deployment_test.yaml
@@ -33,4 +33,42 @@ tests:
           of: PersistentVolumeClaim
       - documentIndex: 5
         isKind:
-          of: PersistentVolumeClaim 
+          of: PersistentVolumeClaim
+
+  - it: should include storageClassName when global.storageClass is set
+    set:
+      global:
+        storageClass: "fast-ssd"
+      clickhouse:
+        enabled: true
+        persistence:
+          enabled: true
+          dataSize: 10Gi
+          logSize: 5Gi
+    asserts:
+      - documentIndex: 4
+        equal:
+          path: spec.storageClassName
+          value: "fast-ssd"
+      - documentIndex: 5
+        equal:
+          path: spec.storageClassName
+          value: "fast-ssd"
+
+  - it: should omit storageClassName when global.storageClass is empty
+    set:
+      global:
+        storageClass: ""
+      clickhouse:
+        enabled: true
+        persistence:
+          enabled: true
+          dataSize: 10Gi
+          logSize: 5Gi
+    asserts:
+      - documentIndex: 4
+        isNull:
+          path: spec.storageClassName
+      - documentIndex: 5
+        isNull:
+          path: spec.storageClassName 

--- a/charts/hdx-oss-v2/tests/hyperdx-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/hyperdx-deployment_test.yaml
@@ -18,6 +18,9 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[1].containerPort
           value: 8000
+      - equal:
+          path: spec.template.spec.containers[0].ports[2].containerPort
+          value: 4320
       - isSubset:
           path: spec.template.spec.containers[0].envFrom[0]
           content:
@@ -86,3 +89,21 @@ tests:
           content:
             name: ANOTHER_ENV
             value: "another-value"
+
+  - it: should expose OpAMP container port with default values
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[2].containerPort
+          value: 4320
+      - equal:
+          path: spec.template.spec.containers[0].ports[2].name
+          value: opamp-port
+  
+  - it: should use custom OpAMP port when provided
+    set:
+      hyperdx:
+        opampPort: 5320
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].ports[2].containerPort
+          value: 5320

--- a/charts/hdx-oss-v2/tests/hyperdx-service_test.yaml
+++ b/charts/hdx-oss-v2/tests/hyperdx-service_test.yaml
@@ -36,3 +36,27 @@ tests:
       - matchRegex:
           path: spec.selector.app
           pattern: ^RELEASE-NAME-hdx-oss-v2$
+
+  - it: should expose OpAMP port with default values
+    asserts:
+      - equal:
+          path: spec.ports[1].port
+          value: 4320
+      - equal:
+          path: spec.ports[1].targetPort
+          value: 4320
+      - equal:
+          path: spec.ports[1].name
+          value: opamp
+  
+  - it: should use custom OpAMP port when provided
+    set:
+      hyperdx:
+        opampPort: 5320
+    asserts:
+      - equal:
+          path: spec.ports[1].port
+          value: 5320
+      - equal:
+          path: spec.ports[1].targetPort
+          value: 5320

--- a/charts/hdx-oss-v2/tests/otel-collector_test.yaml
+++ b/charts/hdx-oss-v2/tests/otel-collector_test.yaml
@@ -308,3 +308,52 @@ tests:
           content:
             name: OPAMP_SERVER_URL
             value: "https://custom-opamp-server:8080"
+
+  - it: should use default clickhouse database when not specified
+    set:
+      otel:
+        enabled: true
+        image: hyperdx/hyperdx-otel-collector:2-beta
+      hyperdx:
+        logLevel: info
+      clickhouse:
+        config:
+          users:
+            otelUserPassword: test-password
+    release:
+      name: test-release
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE
+            value: "default"
+
+  - it: should use custom clickhouse database when specified
+    set:
+      otel:
+        enabled: true
+        image: hyperdx/hyperdx-otel-collector:2-beta
+      hyperdx:
+        logLevel: info
+        clickhouseDatabase: "custom_db"
+      clickhouse:
+        config:
+          users:
+            otelUserPassword: test-password
+    release:
+      name: test-release
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE
+            value: "custom_db"

--- a/charts/hdx-oss-v2/tests/otel-collector_test.yaml
+++ b/charts/hdx-oss-v2/tests/otel-collector_test.yaml
@@ -88,6 +88,12 @@ tests:
           content:
             name: CLICKHOUSE_PASSWORD
             value: test-password
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OPAMP_SERVER_URL
+            value: http://test-release-hdx-oss-v2-app:4320
 
   - it: should render environment variables correctly with custom clickhouse endpoint
     set:
@@ -277,3 +283,28 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT
+
+  - it: should render OPAMP_SERVER_URL with custom value when specified
+    set:
+      otel:
+        enabled: true
+        image: hyperdx/hyperdx-otel-collector:2-beta
+        opampServerUrl: "https://custom-opamp-server:8080"
+      hyperdx:
+        logLevel: info
+      clickhouse:
+        config:
+          users:
+            otelUserPassword: test-password
+    release:
+      name: test-release
+    asserts:
+      - documentIndex: 0
+        isKind:
+          of: Deployment
+      - documentIndex: 0
+        contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: OPAMP_SERVER_URL
+            value: "https://custom-opamp-server:8080"

--- a/charts/hdx-oss-v2/tests/persistence_test.yaml
+++ b/charts/hdx-oss-v2/tests/persistence_test.yaml
@@ -31,3 +31,17 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: should omit storageClassName when global.storageClass is empty string
+    set:
+      global:
+        storageClass: ""
+      persistence:
+        mongodb:
+          enabled: true
+          size: 10Gi
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - isNull:
+          path: spec.storageClassName

--- a/charts/hdx-oss-v2/tests/pvc_test.yaml
+++ b/charts/hdx-oss-v2/tests/pvc_test.yaml
@@ -33,4 +33,30 @@ tests:
           enabled: false
     asserts:
       - hasDocuments:
-          count: 0 
+          count: 0
+
+  - it: should not include storageClassName when global.storageClass is empty
+    set:
+      persistence:
+        mongodb:
+          enabled: true
+          size: 10Gi
+      global:
+        storageClass: ""
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - isNull:
+          path: spec.storageClassName
+
+  - it: should not include storageClassName when global.storageClass is not set
+    set:
+      persistence:
+        mongodb:
+          enabled: true
+          size: 10Gi
+    asserts:
+      - isKind:
+          of: PersistentVolumeClaim
+      - isNull:
+          path: spec.storageClassName 

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -14,6 +14,8 @@ hyperdx:
   usageStatsEnabled: true
   # Endpoint to send hyperdx logs/traces/metrics to.Defaults to the chart's otel collector endpoint.
   otelExporterEndpoint: http://{{ include "hdx-oss.fullname" . }}-otel-collector:{{ .Values.otel.httpPort }}
+  # Clickhouse database to send logs/traces/metrics to. Defaults to "default"
+  clickhouseDatabase: "default"
   annotations: {}
     # myAnnotation: "myValue"
   labels: {}

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -1,7 +1,7 @@
 global:
   imageRegistry: ""
   imagePullSecrets: []
-  storageClassName: []
+  storageClassName: "local-path"
 
 hyperdx:
   image: "hyperdx/hyperdx:2-beta"


### PR DESCRIPTION
* Adds a protocol to the opamp default value
* Exposes opamp port correctly in app service & deployment specs
* Adds env var to collector config to specify default clickhouse database
* Fixes error with storageclass names, preventing chart upgrades
* Adds lots of tests
* Update readme for instructions for self-app instrumentation after install.

Ref: HDX-1805