### PR TITLE
feat: support 'enabled' flag for mongodb service

### DIFF
--- a/charts/hdx-oss-v2/templates/mongodb-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/mongodb-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.mongodb.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -43,3 +44,4 @@ spec:
   selector:
     {{- include "hdx-oss.selectorLabels" . | nindent 4 }}
     app: mongodb
+{{- end }}

--- a/charts/hdx-oss-v2/tests/mongodb-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/mongodb-deployment_test.yaml
@@ -2,11 +2,12 @@ suite: Test MongoDB Deployment
 templates:
   - mongodb-deployment.yaml
 tests:
-  - it: should render both deployment and service
+  - it: should render both deployment and service when enabled
     set:
       mongodb:
         image: mongo:5.0.14-focal
         port: 27017
+        enabled: true
     asserts:
       - hasDocuments:
           count: 2
@@ -16,3 +17,11 @@ tests:
       - documentIndex: 1
         isKind:
           of: Service 
+  
+  - it: should not render any documents when disabled
+    set:
+      mongodb:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -156,6 +156,7 @@ hyperdx:
 mongodb:
   image: "mongo:5.0.14-focal"
   port: 27017
+  enabled: true
 
 clickhouse:
   image: "clickhouse/clickhouse-server:24-alpine"


### PR DESCRIPTION
For people who want to connect hyperdx to external mongodb (or DocumentDB) cluster

Ref: HDX-1833