### PR TITLE
feat: allow additional ingress definitions

### DIFF
--- a/.changeset/angry-lines-repair.md
+++ b/.changeset/angry-lines-repair.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": minor
+---
+
+Allow defining additional ingresses so resources outside of the HyperDX application can accept traffic outside of the cluster.

--- a/.github/workflows/chart-test.yml
+++ b/.github/workflows/chart-test.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   test-helm-chart:
     runs-on: ubuntu-latest
-    
+
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
@@ -55,7 +55,7 @@ jobs:
 
     - name: Run Helm unit tests
       run: |
-        helm plugin install https://github.com/quintush/helm-unittest || true
+        helm plugin install https://github.com/helm-unittest/helm-unittest.git || true
         helm unittest charts/hdx-oss-v2
 
     - name: Deploy HyperDX chart
@@ -66,33 +66,33 @@ jobs:
           apiKey: "test-api-key-for-ci"
           appUrl: "http://localhost:3000"
           replicas: 1
-        
+
         clickhouse:
           persistence:
             enabled: true
             dataSize: 2Gi
             logSize: 1Gi
-        
+
         persistence:
           mongodb:
             enabled: true
             size: 2Gi
-        
+
         # Enable NodePort services for testing
         hyperdx:
           service:
             type: NodePort
             nodePort: 30000
-        
+
         otel:
           service:
             type: NodePort
             nodePort: 30001
         EOF
-        
+
         # Install the chart
         helm install hyperdx-test ./charts/hdx-oss-v2 -f test-values.yaml --timeout=2m
-        
+
         # Give services time to initialize after pods are running
         echo "Waiting for services to initialize..."
         sleep 20
@@ -101,10 +101,10 @@ jobs:
       run: |
         # Wait for all pods to be ready
         kubectl wait --for=condition=Ready pods --all --timeout=300s
-        
+
         # Check pod status
         kubectl get pods -o wide
-        
+
         # Check services
         kubectl get services
 
@@ -112,7 +112,7 @@ jobs:
       run: |
         # Make smoke test script executable
         chmod +x ./scripts/smoke-test.sh
-        
+
         # Run the smoke test with CI-specific environment
         RELEASE_NAME=hyperdx-test NAMESPACE=default ./scripts/smoke-test.sh
 
@@ -121,19 +121,19 @@ jobs:
       run: |
         echo "=== Pod Status ==="
         kubectl get pods -o wide
-        
+
         echo "=== Events ==="
         kubectl get events --sort-by=.metadata.creationTimestamp
-        
+
         echo "=== HyperDX App Logs ==="
         kubectl logs -l app=app --tail=100 || true
-        
+
         echo "=== ClickHouse Logs ==="
         kubectl logs -l app=clickhouse --tail=100 || true
-        
+
         echo "=== MongoDB Logs ==="
         kubectl logs -l app=mongodb --tail=100 || true
-        
+
         echo "=== OTEL Collector Logs ==="
         kubectl logs -l app=otel-collector --tail=100 || true
 

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -26,11 +26,11 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: v3.12.0
-        
+
       - name: Install helm-unittest plugin
         run: |
-          helm plugin install https://github.com/quintush/helm-unittest
-        
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git
+
       - name: Run helm-unittest
         run: |
-          helm unittest charts/hdx-oss-v2 
+          helm unittest charts/hdx-oss-v2

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ hyperdx:
           nginx.ingress.kubernetes.io/ssl-redirect: "false"
           nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
           nginx.ingress.kubernetes.io/use-regex: "true"
+        ingressClassName: nginx
         hosts:
           - host: collector.yourdomain.com
             paths:

--- a/README.md
+++ b/README.md
@@ -106,6 +106,38 @@ hyperdx:
   otelExporterEndpoint: "http://your-otel-collector:4318"
 ```
 
+#### Configuring Ingress for OTEL Collector
+
+If you need to expose your OTEL collector endpoints through ingress, you can use the additional ingresses configuration. The example below uses a regex pattern to capture all OTLP endpoints (traces, metrics, and logs) in a single path rule:
+
+```yaml
+hyperdx:
+  ingress:
+    enabled: true
+    additionalIngresses:
+      - name: otel-collector
+        annotations:
+          nginx.ingress.kubernetes.io/ssl-redirect: "false"
+          nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
+          nginx.ingress.kubernetes.io/use-regex: "true"
+        hosts:
+          - host: collector.yourdomain.com
+            paths:
+              - path: /v1/(traces|metrics|logs)
+                pathType: Prefix
+                port: 4318
+        tls:
+          - hosts:
+              - collector.yourdomain.com
+            secretName: collector-tls
+```
+
+This configuration creates a separate ingress resource for the OTEL collector endpoints, allowing you to:
+- Use a different domain for collector traffic
+- Configure specific TLS settings
+- Apply custom annotations for the collector ingress
+- Route all telemetry signals through a single regex-based path rule
+
 ### Minimal Deployment
 
 For organizations with existing infrastructure:
@@ -285,7 +317,7 @@ helm install my-hyperdx hyperdx/hdx-oss-v2 \
 # values-gke.yaml
 hyperdx:
   appUrl: "http://34.123.61.99"  # Use your LoadBalancer external IP
-  
+
 otel:
   opampServerUrl: "http://my-hyperdx-hdx-oss-v2-app.default.svc.cluster.local:4320"
 

--- a/charts/hdx-oss-v2/templates/ingress.yaml
+++ b/charts/hdx-oss-v2/templates/ingress.yaml
@@ -35,4 +35,59 @@ spec:
                 name: {{ include "hdx-oss.fullname" . }}-app
                 port:
                   number: {{ .Values.hyperdx.appPort }}
+{{- range .Values.hyperdx.ingress.additionalIngresses}}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ printf "%s-%s" (include "hdx-oss.fullname" $) .name }}
+  labels:
+    {{- include "hdx-oss.labels" $ | nindent 4 }}
+  {{- if .annotations }}
+  {{- if not (kindIs "map" .annotations) }}
+  {{- fail "annotations must be a map of string key-value pairs" }}
+  {{- end }}
+  annotations:
+    {{- range $key, $value := .annotations }}
+    {{- printf "%s: %s" $key (tpl $value $ | quote) | nindent 4 }}
+    {{- end }}
+  {{- end }}
+spec:
+  {{- if .ingressClassName }}
+  ingressClassName: {{ .ingressClassName }}
+  {{- end -}}
+  {{- if .tls }}
+  tls:
+    {{- range .tls }}
+    {{- if not .hosts }}
+    {{- fail "TLS configuration must contain hosts property" }}
+    {{- end }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ tpl . $ | quote }}
+        {{- end }}
+      {{- with .secretName }}
+      secretName: {{ . }}
+      {{- end }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .hosts }}
+    - host: {{ tpl .host $ | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          {{- if or (not .path) (not .pathType) (not .port) }}
+          {{- fail "Each path in additional ingress must contain path, pathType, and port properties" }}
+          {{- end }}
+          - path: {{ .path }}
+            pathType: {{ .pathType }}
+            backend:
+              service:
+                name: {{ include "hdx-oss.fullname" $ }}
+                port:
+                  number: {{ .port }}
+          {{- end }}
+    {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/hdx-oss-v2/tests/__snapshot__/ingress_test.yaml.snap
+++ b/charts/hdx-oss-v2/tests/__snapshot__/ingress_test.yaml.snap
@@ -1,0 +1,60 @@
+should render additional ingress templates:
+  1: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        another: "yes"
+        testProperty: "true"
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: hdx-oss-v2
+        app.kubernetes.io/version: 1.0.0
+        helm.sh/chart: hdx-oss-v2-0.5.2
+      name: RELEASE-NAME-hdx-oss-v2-otel-collector
+    spec:
+      ingressClassName: nginx
+      rules:
+        - host: collector.example.com
+          http:
+            paths:
+              - backend:
+                  service:
+                    name: RELEASE-NAME-hdx-oss-v2
+                    port:
+                      number: 4318
+                path: /
+                pathType: Prefix
+should render additional ingress templates with TLS enabled:
+  1: |
+    apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      annotations:
+        another: "yes"
+        testProperty: "true"
+      labels:
+        app.kubernetes.io/instance: RELEASE-NAME
+        app.kubernetes.io/managed-by: Helm
+        app.kubernetes.io/name: hdx-oss-v2
+        app.kubernetes.io/version: 1.0.0
+        helm.sh/chart: hdx-oss-v2-0.5.2
+      name: RELEASE-NAME-hdx-oss-v2-otel-collector
+    spec:
+      ingressClassName: nginx
+      rules:
+        - host: collector.example.com
+          http:
+            paths:
+              - backend:
+                  service:
+                    name: RELEASE-NAME-hdx-oss-v2
+                    port:
+                      number: 4318
+                path: /
+                pathType: Prefix
+      tls:
+        - hosts:
+            - collector.example.com
+          secretName: otel-collector-tls

--- a/charts/hdx-oss-v2/tests/ingress_test.yaml
+++ b/charts/hdx-oss-v2/tests/ingress_test.yaml
@@ -2,7 +2,7 @@ suite: Test Ingress
 templates:
   - ingress.yaml
 tests:
-  - it: should not render ingress when disabled
+  - it: should not render any ingress templates when disabled
     set:
       hyperdx:
         ingress:
@@ -10,8 +10,8 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-          
-  - it: should render ingress correctly when enabled without TLS
+
+  - it: should render the app ingress template correctly when enabled without TLS
     set:
       hyperdx:
         ingress:
@@ -24,6 +24,8 @@ tests:
           tls:
             enabled: false
     asserts:
+      - hasDocuments:
+          count: 1
       - isKind:
           of: Ingress
       - equal:
@@ -52,8 +54,8 @@ tests:
       - matchRegex:
           path: metadata.labels["helm.sh/chart"]
           pattern: ^hdx-oss-v2-\d+\.\d+\.\d+$
-          
-  - it: should render ingress with TLS when enabled
+
+  - it: should render the app ingress template  with TLS when enabled
     set:
       hyperdx:
         ingress:
@@ -63,6 +65,8 @@ tests:
             enabled: true
             secretName: hyperdx-tls
     asserts:
+      - hasDocuments:
+          count: 1
       - isKind:
           of: Ingress
       - equal:
@@ -70,4 +74,160 @@ tests:
           value: hyperdx.example.com
       - equal:
           path: spec.tls[0].secretName
-          value: hyperdx-tls 
+          value: hyperdx-tls
+
+  - it: should render additional ingress templates
+    set:
+      hyperdx:
+        ingress:
+          enabled: true
+          host: hyperdx.example.com
+          tls:
+            enabled: false
+          additionalIngresses:
+            - name: otel-collector
+              annotations:
+                testProperty: "true"
+                another: "yes"
+              ingressClassName: nginx
+              hosts:
+                - host: collector.example.com
+                  paths:
+                    - path: /
+                      pathType: Prefix
+                      port: 4318
+    asserts:
+      - hasDocuments:
+          count: 2
+      - matchSnapshot: {}
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-hdx-oss-v2-otel-collector
+
+  - it: should render additional ingress templates with TLS enabled
+    set:
+      hyperdx:
+        ingress:
+          enabled: true
+          host: hyperdx.example.com
+          tls:
+            enabled: false
+          additionalIngresses:
+            - name: otel-collector
+              annotations:
+                testProperty: "true"
+                another: "yes"
+              ingressClassName: nginx
+              hosts:
+                - host: collector.example.com
+                  paths:
+                    - path: /
+                      pathType: Prefix
+                      port: 4318
+              tls:
+                - secretName: otel-collector-tls
+                  hosts:
+                    - collector.example.com
+    asserts:
+      - hasDocuments:
+          count: 2
+      - matchSnapshot: {}
+        documentSelector:
+          path: metadata.name
+          value: RELEASE-NAME-hdx-oss-v2-otel-collector
+
+  - it: should fail when annotations of the additional ingresses is not a map of strings
+    set:
+      hyperdx:
+        ingress:
+          enabled: true
+          additionalIngresses:
+            - name: otel-collector
+              annotations:
+                - invalid: "annotation"
+                - format: "here"
+              ingressClassName: nginx
+              hosts:
+                - host: collector.example.com
+                  paths:
+                    - path: /
+                      pathType: Prefix
+                      port: 4318
+    asserts:
+      - failedTemplate:
+          errorMessage: "annotations must be a map of string key-value pairs"
+
+  - it: should fail when TLS configuration specifies secretName without hosts
+    set:
+      hyperdx:
+        ingress:
+          enabled: true
+          additionalIngresses:
+            - name: otel-collector
+              ingressClassName: nginx
+              hosts:
+                - host: collector.example.com
+                  paths:
+                    - path: /
+                      pathType: Prefix
+                      port: 4318
+              tls:
+                - secretName: otel-collector-tls
+                  # hosts property is missing
+    asserts:
+      - failedTemplate:
+          errorMessage: "TLS configuration must contain hosts property"
+
+  - it: should fail when paths object is missing path property
+    set:
+      hyperdx:
+        ingress:
+          enabled: true
+          additionalIngresses:
+            - name: otel-collector
+              ingressClassName: nginx
+              hosts:
+                - host: collector.example.com
+                  paths:
+                    - pathType: Prefix
+                      port: 4318
+                      # path is missing
+    asserts:
+      - failedTemplate:
+          errorMessage: "Each path in additional ingress must contain path, pathType, and port properties"
+
+  - it: should fail when paths object is missing pathType property
+    set:
+      hyperdx:
+        ingress:
+          enabled: true
+          additionalIngresses:
+            - name: otel-collector
+              ingressClassName: nginx
+              hosts:
+                - host: collector.example.com
+                  paths:
+                    - path: /
+                      port: 4318
+                      # pathType is missing
+    asserts:
+      - failedTemplate:
+          errorMessage: "Each path in additional ingress must contain path, pathType, and port properties"
+
+  - it: should fail when paths object is missing port property
+    set:
+      hyperdx:
+        ingress:
+          enabled: true
+          additionalIngresses:
+            - name: otel-collector
+              ingressClassName: nginx
+              hosts:
+                - host: collector.example.com
+                  paths:
+                    - path: /
+                      pathType: Prefix
+                      # port is missing
+    asserts:
+      - failedTemplate:
+          errorMessage: "Each path in additional ingress must contain path, pathType, and port properties"

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -136,7 +136,7 @@ hyperdx:
         "metricSourceId": "Metrics"
       }
     ]
-  
+
   # See https://github.com/hyperdxio/hyperdx/blob/v2/packages/api/docs/auto_provision/AUTO_PROVISION.md
   # for detailed configuration options
 
@@ -150,6 +150,25 @@ hyperdx:
     tls:
       enabled: false
       secretName: "hyperdx-tls"
+
+    # Additional ingresses - these will only be rendered if the whole ingress object is enabled
+    # This should be used to expose other deployments/services from the helm chart on the cluster
+    # e.g. expose the OTEL collector.
+    additionalIngresses: []
+    # - name: otel-collector
+    #   annotations: {}
+    #   ingressClassName: nginx
+    #   hosts:
+    #     - host: collector.example.com
+    #       paths:
+    #         - path: /
+    #           pathType: Prefix
+    #           port: 4318
+    #   tls:
+    #     - secretName: otel-collector-tls
+    #       hosts:
+    #         - collector.example.com
+
   replicas: 1
 
 mongodb:
@@ -205,7 +224,7 @@ otel:
   clickhouseEndpoint:
   clickhouseUser:
   clickhousePassword:
-  # Clickhouse Prometheus endpoint - defaults to chart's Clickhouse prometheus service. Customize if you want to use a different Clickhouse prometheus service. 
+  # Clickhouse Prometheus endpoint - defaults to chart's Clickhouse prometheus service. Customize if you want to use a different Clickhouse prometheus service.
   # Leave empty if prometheus is disabled.
   # Example: clickhousePrometheusEndpoint: "http://custom-clickhouse-service:9363"
   clickhousePrometheusEndpoint:


### PR DESCRIPTION
Adds a method for supplying additional ingress definitions, which allows users to expose any other helm chart resources outside of the cluster.

Ref: HDX-1843