### PR TITLE
fix typo

### DIFF
--- a/.changeset/cruel-trees-join.md
+++ b/.changeset/cruel-trees-join.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+fix if condition typo

--- a/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
@@ -28,7 +28,7 @@ spec:
         {{- end -}}
       {{- end }}
     spec:
-      {{- if not .Values.mongodb.enabled }}
+      {{- if .Values.mongodb.enabled }}
       initContainers:
         - name: wait-for-mongodb
           image: busybox

--- a/charts/hdx-oss-v2/tests/hyperdx-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/hyperdx-deployment_test.yaml
@@ -107,3 +107,25 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].ports[2].containerPort
           value: 5320
+  - it: should include initContainers when mongodb.enabled is true
+    set:
+      mongodb:
+        enabled: true
+    asserts:
+      - isNotEmpty:
+          path: spec.template.spec.initContainers
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-mongodb
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: busybox
+      - contains:
+          path: spec.template.spec.initContainers[0].command
+          content: sh
+      - contains:
+          path: spec.template.spec.initContainers[0].command
+          content: -c
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: "until nc -z .+-mongodb [0-9]+; do echo waiting for mongodb; sleep 2; done;"


### PR DESCRIPTION
I had a mistake before  https://github.com/hyperdxio/helm-charts/pull/29/files#diff-a32468ffc6e97c35e5d2cf46c1793d0bcd937a43703fded1b89605571f1e7e78R31
If MongoDB is disabled, the initContainer should be removed, but I did the opposite.
So fixed this.

