### PR TITLE
fix: Fix pathType for ingress

### DIFF
--- a/.changeset/soft-ants-hear.md
+++ b/.changeset/soft-ants-hear.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+fix: Fix pathType for ingress

--- a/charts/hdx-oss-v2/templates/ingress.yaml
+++ b/charts/hdx-oss-v2/templates/ingress.yaml
@@ -34,7 +34,7 @@ spec:
       http:
         paths:
           - path: /(.*)
-            pathType: Prefix
+            pathType: ImplementationSpecific
             backend:
               service:
                 name: {{ include "hdx-oss.fullname" . }}-app

--- a/charts/hdx-oss-v2/tests/ingress_test.yaml
+++ b/charts/hdx-oss-v2/tests/ingress_test.yaml
@@ -31,6 +31,13 @@ tests:
       - equal:
           path: spec.rules[0].host
           value: hyperdx.example.com
+      # Validate main app ingress path configuration
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /(.*)
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: ImplementationSpecific
       # Validate ingress annotations
       - equal:
           path: metadata.annotations
@@ -152,6 +159,13 @@ tests:
       - equal:
           path: spec.rules[0].host
           value: hyperdx.example.com
+      # Validate main app ingress path configuration
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /(.*)
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: ImplementationSpecific
       - equal:
           path: spec.tls[0].secretName
           value: hyperdx-tls
@@ -195,6 +209,15 @@ tests:
       - equal:
           path: spec.rules[0].host
           value: hyperdx.example.com
+        documentIndex: 0
+      # Validate main app ingress path configuration
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /(.*)
+        documentIndex: 0
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: ImplementationSpecific
         documentIndex: 0
       # Test the additional otel-collector ingress (document 1)
       - isKind:
@@ -280,6 +303,15 @@ tests:
       - equal:
           path: spec.rules[0].host
           value: hyperdx.example.com
+        documentIndex: 0
+      # Validate main app ingress path configuration
+      - equal:
+          path: spec.rules[0].http.paths[0].path
+          value: /(.*)
+        documentIndex: 0
+      - equal:
+          path: spec.rules[0].http.paths[0].pathType
+          value: ImplementationSpecific
         documentIndex: 0
       # Test the additional otel-collector ingress (document 1)
       - isKind:


### PR DESCRIPTION
Fixes an error with some kubernetes versions, " ingress contains invalid paths: path /(.*) cannot be used with pathType Prefix" See: https://kubernetes.github.io/ingress-nginx/faq/#validation-of-path

Fixes: HDX-1870