### PR TITLE
fix: Allow for configurable service type + annotations

### DIFF
--- a/.changeset/plenty-pears-yawn.md
+++ b/.changeset/plenty-pears-yawn.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+fix: Allow for configurable service type + annotations

--- a/charts/hdx-oss-v2/templates/NOTES.txt
+++ b/charts/hdx-oss-v2/templates/NOTES.txt
@@ -6,7 +6,26 @@ it is recommended that you use the clickhouse and otel-collector operators inste
 To disable clickhouse and otel-collector, set the following values:
 helm install myrelease hyperdx-helm --set clickhouse.enabled=false --set clickhouse.persistence.enabled=false --set otel.enabled=false
 
-Application URL: {{ include "hdx-oss.fullname" . }}-app:{{ .Values.hyperdx.appPort }}
+{{- if .Values.hyperdx.ingress.enabled }}
+Application URL: {{ if .Values.hyperdx.ingress.tls.enabled }}https{{ else }}http{{ end }}://{{ .Values.hyperdx.ingress.host }}
+{{- else }}
+Application Access:
+  For security, the service uses ClusterIP and is not exposed externally by default.
+  Choose one of the following secure access methods:
+  
+  1. Enable Ingress with TLS (Recommended for Production):
+     helm upgrade {{ .Release.Name }} hyperdx-helm \
+       --set hyperdx.ingress.enabled=true \
+       --set hyperdx.ingress.host=your-domain.com \
+       --set hyperdx.ingress.tls.enabled=true
+  
+  2. Port Forward (Development/Testing):
+     kubectl port-forward svc/{{ include "hdx-oss.fullname" . }}-app {{ .Values.hyperdx.appPort }}:{{ .Values.hyperdx.appPort }}
+     Then access: http://localhost:{{ .Values.hyperdx.appPort }}
+  
+  Note: This application handles sensitive telemetry data and should not be exposed
+  directly to the internet without proper authentication and encryption.
+{{- end }}
 
 To verify the deployment status, run:
   kubectl get pods -l "app.kubernetes.io/name={{ include "hdx-oss.name" . }}" 

--- a/charts/hdx-oss-v2/templates/NOTES.txt
+++ b/charts/hdx-oss-v2/templates/NOTES.txt
@@ -4,7 +4,7 @@ Note: By default, this chart also installs clickhouse and the otel-collector. Ho
 it is recommended that you use the clickhouse and otel-collector operators instead.
 
 To disable clickhouse and otel-collector, set the following values:
-helm install myrelease hyperdx-helm --set clickhouse.enabled=false --set clickhouse.persistence.enabled=false --set otel.enabled=false
+helm install myrelease <chart-name-or-path> --set clickhouse.enabled=false --set clickhouse.persistence.enabled=false --set otel.enabled=false
 
 {{- if .Values.hyperdx.ingress.enabled }}
 Application URL: {{ if .Values.hyperdx.ingress.tls.enabled }}https{{ else }}http{{ end }}://{{ .Values.hyperdx.ingress.host }}
@@ -14,7 +14,7 @@ Application Access:
   Choose one of the following secure access methods:
   
   1. Enable Ingress with TLS (Recommended for Production):
-     helm upgrade {{ .Release.Name }} hyperdx-helm \
+     helm upgrade {{ .Release.Name }} <chart-name-or-path> \
        --set hyperdx.ingress.enabled=true \
        --set hyperdx.ingress.host=your-domain.com \
        --set hyperdx.ingress.tls.enabled=true

--- a/charts/hdx-oss-v2/templates/hyperdx-service.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-service.yaml
@@ -4,8 +4,14 @@ metadata:
   name: {{ include "hdx-oss.fullname" . }}-app
   labels:
     {{- include "hdx-oss.labels" . | nindent 4 }}
+  {{- if .Values.hyperdx.service.annotations }}
+  annotations:
+    {{- with .Values.hyperdx.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 spec:
-  type: LoadBalancer
+  type: {{ .Values.hyperdx.service.type | default "ClusterIP" }}
   ports:
     - port: {{ .Values.hyperdx.appPort }}
       targetPort: {{ .Values.hyperdx.appPort }}
@@ -15,4 +21,4 @@ spec:
       name: opamp
   selector:
     {{- include "hdx-oss.selectorLabels" . | nindent 4 }}
-    app: {{ include "hdx-oss.fullname" . }} 
+    app: {{ include "hdx-oss.fullname" . }}

--- a/charts/hdx-oss-v2/tests/hyperdx-service_test.yaml
+++ b/charts/hdx-oss-v2/tests/hyperdx-service_test.yaml
@@ -8,7 +8,7 @@ tests:
           of: Service
       - equal:
           path: spec.type
-          value: LoadBalancer
+          value: ClusterIP
       - equal:
           path: spec.ports[0].port
           value: 3000
@@ -18,7 +18,53 @@ tests:
       - equal:
           path: spec.ports[0].name
           value: app
-  
+      - isNull:
+          path: metadata.annotations
+
+  - it: should use LoadBalancer type when configured
+    set:
+      hyperdx:
+        service:
+          type: LoadBalancer
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+
+  - it: should use NodePort type when configured
+    set:
+      hyperdx:
+        service:
+          type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: NodePort
+
+  - it: should render service annotations when provided
+    set:
+      hyperdx:
+        service:
+          annotations:
+            service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+            service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    asserts:
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-internal"]
+          value: "true"
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/aws-load-balancer-type"]
+          value: "nlb"
+
+  - it: should not render annotations section when annotations are empty
+    set:
+      hyperdx:
+        service:
+          annotations: {}
+    asserts:
+      - isNull:
+          path: metadata.annotations
+
   - it: should use custom port when provided
     set:
       hyperdx:
@@ -60,3 +106,31 @@ tests:
       - equal:
           path: spec.ports[1].targetPort
           value: 5320
+
+  - it: should combine LoadBalancer type with annotations
+    set:
+      hyperdx:
+        service:
+          type: LoadBalancer
+          annotations:
+            cloud.google.com/load-balancer-type: "Internal"
+            service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    asserts:
+      - equal:
+          path: spec.type
+          value: LoadBalancer
+      - equal:
+          path: metadata.annotations["cloud.google.com/load-balancer-type"]
+          value: "Internal"
+      - equal:
+          path: metadata.annotations["service.beta.kubernetes.io/azure-load-balancer-internal"]
+          value: "true"
+
+  - it: should fallback to ClusterIP when service type is not specified
+    set:
+      hyperdx:
+        service: {}
+    asserts:
+      - equal:
+          path: spec.type
+          value: ClusterIP

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -18,8 +18,12 @@ hyperdx:
   # Endpoint to send hyperdx logs/traces/metrics to.Defaults to the chart's otel collector endpoint.
   otelExporterEndpoint: http://{{ include "hdx-oss.fullname" . }}-otel-collector:{{ .Values.otel.httpPort }}
   mongoUri: mongodb://{{ include "hdx-oss.fullname" . }}-mongodb:{{ .Values.mongodb.port }}/hyperdx
+  
+  # Pod-level annotations (applied to the deployment pods)
   annotations: {}
     # myAnnotation: "myValue"
+  
+  # Pod-level labels (applied to the deployment pods)  
   labels: {}
     # myLabel: "myValue"
   env: []
@@ -175,6 +179,15 @@ hyperdx:
     #         - collector.example.com
 
   replicas: 1
+
+  # Service configuration
+  service:
+    type: ClusterIP  # Use ClusterIP for security. For external access, use ingress with proper TLS and authentication
+    # Service-level annotations (applied to the Kubernetes service resource)
+    annotations: {}
+      # Example service annotations:
+      # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+      # cloud.google.com/load-balancer-type: "Internal"
 
 mongodb:
   image: "mongo:5.0.14-focal"


### PR DESCRIPTION
* Changes default service deployment to ClusterIP
* Allows for configurable service type
* Allow for annotations in the service chart
* Updates NOTES.txt after chart is deployed

Fixes: HDX-1900