### PR TITLE
fix: Update FRONTEND_URL to be dynamic w/ingress

### DIFF
--- a/.changeset/plenty-olives-visit.md
+++ b/.changeset/plenty-olives-visit.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+fix: Update FRONTEND_URL to be dynamic w/ingress

--- a/charts/hdx-oss-v2/templates/configmaps/app-configmap.yaml
+++ b/charts/hdx-oss-v2/templates/configmaps/app-configmap.yaml
@@ -7,7 +7,11 @@ metadata:
 data:
   APP_PORT: {{ .Values.hyperdx.appPort | quote }}
   API_PORT: {{ .Values.hyperdx.apiPort | quote }}
+  {{- if .Values.hyperdx.ingress.enabled }}
+  FRONTEND_URL: "{{ if .Values.hyperdx.ingress.tls.enabled }}https{{ else }}http{{ end }}://{{ .Values.hyperdx.ingress.host }}"
+  {{- else }}
   FRONTEND_URL: "{{ .Values.hyperdx.appUrl }}:{{ .Values.hyperdx.appPort }}"
+  {{- end }}
   HYPERDX_API_PORT: "{{ .Values.hyperdx.apiPort }}"
   HYPERDX_APP_PORT: "{{ .Values.hyperdx.appPort }}"
   HYPERDX_APP_URL: "{{ .Values.hyperdx.appUrl }}"

--- a/charts/hdx-oss-v2/tests/configmap_test.yaml
+++ b/charts/hdx-oss-v2/tests/configmap_test.yaml
@@ -2,7 +2,7 @@ suite: Test ConfigMap
 templates:
   - configmaps/app-configmap.yaml
 tests:
-  - it: should render app configmap correctly
+  - it: should render app configmap correctly with default values
     set:
       hyperdx:
         apiPort: 8000
@@ -40,4 +40,49 @@ tests:
           value: "false"
       - matchRegex:
           path: data.MONGO_URI
-          pattern: mongodb://.*-mongodb:27017/hyperdx 
+          pattern: mongodb://.*-mongodb:27017/hyperdx
+
+  - it: should use ingress URL for FRONTEND_URL when ingress is enabled
+    set:
+      hyperdx:
+        apiPort: 8000
+        appPort: 3000
+        appUrl: http://localhost
+        ingress:
+          enabled: true
+          host: hyperdx.example.com
+          tls:
+            enabled: false
+    asserts:
+      - equal:
+          path: data.FRONTEND_URL
+          value: "http://hyperdx.example.com"
+
+  - it: should use ingress HTTPS URL for FRONTEND_URL when TLS is enabled
+    set:
+      hyperdx:
+        apiPort: 8000
+        appPort: 3000
+        appUrl: http://localhost
+        ingress:
+          enabled: true
+          host: hyperdx.example.com
+          tls:
+            enabled: true
+    asserts:
+      - equal:
+          path: data.FRONTEND_URL
+          value: "https://hyperdx.example.com"
+
+  - it: should fallback to appUrl:port when ingress is disabled
+    set:
+      hyperdx:
+        apiPort: 8000
+        appPort: 4000
+        appUrl: http://custom-host
+        ingress:
+          enabled: false
+    asserts:
+      - equal:
+          path: data.FRONTEND_URL
+          value: "http://custom-host:4000"


### PR DESCRIPTION
When ingress is enabled, the FRONTEND_URL had the wrong value, causing internal links to break like team invites. This has been updated.

Fixes: HDX-1901