### PR TITLE
fix(storageClassName): storageClass in templates has incorrect name

### DIFF
--- a/charts/hdx-oss-v2/templates/claims/persistent-volume-claims.yaml
+++ b/charts/hdx-oss-v2/templates/claims/persistent-volume-claims.yaml
@@ -8,8 +8,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  {{- if .Values.global.storageClass }}
-  storageClassName: {{ .Values.global.storageClass }}
+  {{- if .Values.global.storageClassName }}
+  storageClassName: {{ .Values.global.storageClassName }}
   {{- end }}
   resources:
     requests:

--- a/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
@@ -123,8 +123,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  {{- if .Values.global.storageClass }}
-  storageClassName: {{ .Values.global.storageClass }}
+  {{- if .Values.global.storageClassName }}
+  storageClassName: {{ .Values.global.storageClassName }}
   {{- end }}
   resources:
     requests:
@@ -139,8 +139,8 @@ metadata:
 spec:
   accessModes:
     - ReadWriteOnce
-  {{- if .Values.global.storageClass }}
-  storageClassName: {{ .Values.global.storageClass }}
+  {{- if .Values.global.storageClassName }}
+  storageClassName: {{ .Values.global.storageClassName }}
   {{- end }}
   resources:
     requests:

--- a/charts/hdx-oss-v2/tests/clickhouse-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/clickhouse-deployment_test.yaml
@@ -35,10 +35,10 @@ tests:
         isKind:
           of: PersistentVolumeClaim
 
-  - it: should include storageClassName when global.storageClass is set
+  - it: should include storageClassName when global.storageClassName is set
     set:
       global:
-        storageClass: "fast-ssd"
+        storageClassName: "fast-ssd"
       clickhouse:
         enabled: true
         persistence:
@@ -55,10 +55,10 @@ tests:
           path: spec.storageClassName
           value: "fast-ssd"
 
-  - it: should omit storageClassName when global.storageClass is empty
+  - it: should omit storageClassName when global.storageClassName is empty
     set:
       global:
-        storageClass: ""
+        storageClassName: ""
       clickhouse:
         enabled: true
         persistence:

--- a/charts/hdx-oss-v2/tests/persistence_test.yaml
+++ b/charts/hdx-oss-v2/tests/persistence_test.yaml
@@ -5,7 +5,7 @@ tests:
   - it: should use correct mongodb PVC name and size
     set:
       global:
-        storageClass: "custom-storage-class"
+        storageClassName: "custom-storage-class"
       mongodb:
         persistence:
           enabled: true
@@ -32,10 +32,10 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should omit storageClassName when global.storageClass is empty string
+  - it: should omit storageClassName when global.storageClassName is empty string
     set:
       global:
-        storageClass: ""
+        storageClassName: ""
       mongodb:
         persistence:
           enabled: true

--- a/charts/hdx-oss-v2/tests/pvc_test.yaml
+++ b/charts/hdx-oss-v2/tests/pvc_test.yaml
@@ -9,7 +9,7 @@ tests:
           enabled: true
           dataSize: 10Gi
       global:
-        storageClass: standard
+        storageClassName: standard
     asserts:
       - isKind:
           of: PersistentVolumeClaim
@@ -35,21 +35,21 @@ tests:
       - hasDocuments:
           count: 0
 
-  - it: should not include storageClassName when global.storageClass is empty
+  - it: should not include storageClassName when global.storageClassName is empty
     set:
       mongodb:
         persistence:
           enabled: true
           dataSize: 10Gi
       global:
-        storageClass: ""
+        storageClassName: ""
     asserts:
       - isKind:
           of: PersistentVolumeClaim
       - isNull:
           path: spec.storageClassName
 
-  - it: should not include storageClassName when global.storageClass is not set
+  - it: should not include storageClassName when global.storageClassName is not set
     set:
       mongodb:
         persistence:


### PR DESCRIPTION
In the helm templates, the value for `storageClassName` was looking for `storageClass` not `storageClassName`. It's named `storageClassName` in the values.yaml.