### PR TITLE
fix: rename CRON_IN_APP_DISABLED to RUN_SCHEDULED_TASKS_EXTERNALLY

### DIFF
--- a/.changeset/purple-mirrors-tell.md
+++ b/.changeset/purple-mirrors-tell.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+fix: rename CRON_IN_APP_DISABLED to RUN_SCHEDULED_TASKS_EXTERNALLY

--- a/charts/hdx-oss-v2/templates/configmaps/app-configmap.yaml
+++ b/charts/hdx-oss-v2/templates/configmaps/app-configmap.yaml
@@ -20,6 +20,6 @@ data:
   MONGO_URI: "{{ tpl .Values.hyperdx.mongoUri . }}"
   OTEL_SERVICE_NAME: "hdx-oss-api"
   USAGE_STATS_ENABLED: "{{ .Values.hyperdx.usageStatsEnabled | default true }}"
-  CRON_IN_APP_DISABLED: "{{ .Values.tasks.enabled | default false }}"
+  RUN_SCHEDULED_TASKS_EXTERNALLY: "{{ .Values.tasks.enabled | default false }}"
   OPAMP_PORT: "{{ .Values.hyperdx.opampPort }}"
   OTEL_EXPORTER_OTLP_ENDPOINT: "{{ tpl .Values.hyperdx.otelExporterEndpoint . }}"

--- a/charts/hdx-oss-v2/templates/cronjobs/task-checkAlerts.yaml
+++ b/charts/hdx-oss-v2/templates/cronjobs/task-checkAlerts.yaml
@@ -31,6 +31,8 @@ spec:
                   value: "production"
                 - name: OTEL_SERVICE_NAME
                   value: "hdx-oss-task-check-alerts"
+                - name: APP_TYPE
+                  value: "scheduled-task"
               resources:
                 {{- toYaml .Values.tasks.checkAlerts.resources | nindent 16 }}
 {{- end }}

--- a/charts/hdx-oss-v2/tests/configmap_test.yaml
+++ b/charts/hdx-oss-v2/tests/configmap_test.yaml
@@ -36,7 +36,7 @@ tests:
           path: data.USAGE_STATS_ENABLED
           value: "true"
       - equal:
-          path: data.CRON_IN_APP_DISABLED
+          path: data.RUN_SCHEDULED_TASKS_EXTERNALLY
           value: "false"
       - matchRegex:
           path: data.MONGO_URI


### PR DESCRIPTION
`CRON_IN_APP_DISABLED` is deprecated and not used any longer