### PR TITLE
feat: add livenessProbe and readinessProbe to all services

### DIFF
--- a/.changeset/pretty-ants-arrive.md
+++ b/.changeset/pretty-ants-arrive.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+feat: add livenessProbe and readinessProbe for services

--- a/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
@@ -35,22 +35,26 @@ spec:
           env:
             - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
               value: "1"
+          {{- if .Values.clickhouse.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /ping
               port: {{ .Values.clickhouse.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.clickhouse.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.clickhouse.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.clickhouse.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.clickhouse.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.clickhouse.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /ping
               port: {{ .Values.clickhouse.port }}
-            initialDelaySeconds: 1
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.clickhouse.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.clickhouse.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.clickhouse.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.clickhouse.readinessProbe.failureThreshold }}
+          {{- end }}
           volumeMounts:
             - name: config
               mountPath: /etc/clickhouse-server/config.xml

--- a/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
@@ -35,6 +35,22 @@ spec:
           env:
             - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
               value: "1"
+          livenessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.clickhouse.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.clickhouse.port }}
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           volumeMounts:
             - name: config
               mountPath: /etc/clickhouse-server/config.xml

--- a/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
@@ -64,22 +64,26 @@ spec:
           resources:
             {{- toYaml .Values.hyperdx.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.hyperdx.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /health
               port: {{ .Values.hyperdx.apiPort }}
-            initialDelaySeconds: 10
-            periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.hyperdx.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.hyperdx.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.hyperdx.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.hyperdx.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.hyperdx.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /health
               port: {{ .Values.hyperdx.apiPort }}
-            initialDelaySeconds: 1
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.hyperdx.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.hyperdx.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.hyperdx.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.hyperdx.readinessProbe.failureThreshold }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "hdx-oss.fullname" . }}-app-config

--- a/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
@@ -64,6 +64,22 @@ spec:
           resources:
             {{- toYaml .Values.hyperdx.resources | nindent 12 }}
           {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.hyperdx.apiPort }}
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: {{ .Values.hyperdx.apiPort }}
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           envFrom:
             - configMapRef:
                 name: {{ include "hdx-oss.fullname" . }}-app-config

--- a/charts/hdx-oss-v2/templates/mongodb-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/mongodb-deployment.yaml
@@ -31,6 +31,26 @@ spec:
           image: "{{ .Values.mongodb.image }}"
           ports:
             - containerPort: {{ .Values.mongodb.port }}
+          livenessProbe:
+            exec:
+              command:
+                - mongosh
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            exec:
+              command:
+                - mongosh
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           volumeMounts:
             - name: mongodb-data
               mountPath: /data/db

--- a/charts/hdx-oss-v2/templates/mongodb-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/mongodb-deployment.yaml
@@ -31,20 +31,24 @@ spec:
           image: "{{ .Values.mongodb.image }}"
           ports:
             - containerPort: {{ .Values.mongodb.port }}
+          {{- if .Values.mongodb.livenessProbe.enabled }}
           livenessProbe:
             tcpSocket:
               port: {{ .Values.mongodb.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.mongodb.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.mongodb.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.mongodb.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.mongodb.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.mongodb.readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:
               port: {{ .Values.mongodb.port }}
-            initialDelaySeconds: 1
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.mongodb.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.mongodb.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.mongodb.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.mongodb.readinessProbe.failureThreshold }}
+          {{- end }}
           volumeMounts:
             - name: mongodb-data
               mountPath: /data/db

--- a/charts/hdx-oss-v2/templates/mongodb-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/mongodb-deployment.yaml
@@ -32,21 +32,15 @@ spec:
           ports:
             - containerPort: {{ .Values.mongodb.port }}
           livenessProbe:
-            exec:
-              command:
-                - mongosh
-                - --eval
-                - "db.adminCommand('ping')"
+            tcpSocket:
+              port: {{ .Values.mongodb.port }}
             initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
-            exec:
-              command:
-                - mongosh
-                - --eval
-                - "db.adminCommand('ping')"
+            tcpSocket:
+              port: {{ .Values.mongodb.port }}
             initialDelaySeconds: 1
             periodSeconds: 10
             timeoutSeconds: 5

--- a/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
@@ -46,6 +46,22 @@ spec:
           resources:
             {{- toYaml .Values.otel.resources | nindent 12 }}
           {{- end }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.otel.port }}
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+          readinessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.otel.port }}
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
           env:
             - name: CLICKHOUSE_ENDPOINT
               value: "{{ .Values.otel.clickhouseEndpoint | default (printf "tcp://%s-clickhouse:%v?dial_timeout=10s" (include "hdx-oss.fullname" .) .Values.clickhouse.nativePort) }}"

--- a/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/otel-collector-deployment.yaml
@@ -46,22 +46,26 @@ spec:
           resources:
             {{- toYaml .Values.otel.resources | nindent 12 }}
           {{- end }}
+          {{- if .Values.otel.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
               path: /
               port: {{ .Values.otel.port }}
-            initialDelaySeconds: 10
-            periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.otel.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.otel.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.otel.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.otel.livenessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.otel.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
               path: /
               port: {{ .Values.otel.port }}
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
+            initialDelaySeconds: {{ .Values.otel.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.otel.readinessProbe.periodSeconds}}
+            timeoutSeconds: {{ .Values.otel.readinessProbe.timeoutSeconds}}
+            failureThreshold: {{ .Values.otel.readinessProbe.failureThreshold }}
+          {{- end }}
           env:
             - name: CLICKHOUSE_ENDPOINT
               value: "{{ .Values.otel.clickhouseEndpoint | default (printf "tcp://%s-clickhouse:%v?dial_timeout=10s" (include "hdx-oss.fullname" .) .Values.clickhouse.nativePort) }}"

--- a/charts/hdx-oss-v2/tests/clickhouse-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/clickhouse-deployment_test.yaml
@@ -146,3 +146,54 @@ tests:
       - documentIndex: 0
         isNull:
           path: spec.template.spec.volumes[3].persistentVolumeClaim
+
+  - it: should include livenessProbe with default values
+    set:
+      clickhouse:
+        enabled: true
+        port: 8123
+    asserts:
+      - documentIndex: 0
+        isSubset:
+          path: spec.template.spec.containers[0].livenessProbe
+          content:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+  - it: should include readinessProbe with default values
+    set:
+      clickhouse:
+        enabled: true
+        port: 8123
+    asserts:
+      - documentIndex: 0
+        isSubset:
+          path: spec.template.spec.containers[0].readinessProbe
+          content:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+  - it: should use custom port in probes when provided
+    set:
+      clickhouse:
+        enabled: true
+        port: 8124
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 8124
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8124

--- a/charts/hdx-oss-v2/tests/clickhouse-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/clickhouse-deployment_test.yaml
@@ -147,7 +147,7 @@ tests:
         isNull:
           path: spec.template.spec.volumes[3].persistentVolumeClaim
 
-  - it: should include livenessProbe with default values
+  - it: should include livenessProbe with default values when enabled
     set:
       clickhouse:
         enabled: true
@@ -165,7 +165,7 @@ tests:
             timeoutSeconds: 5
             failureThreshold: 3
 
-  - it: should include readinessProbe with default values
+  - it: should include readinessProbe with default values when enabled
     set:
       clickhouse:
         enabled: true
@@ -182,6 +182,76 @@ tests:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+
+  - it: should not include livenessProbe when disabled
+    set:
+      clickhouse:
+        enabled: true
+        livenessProbe:
+          enabled: false
+    asserts:
+      - documentIndex: 0
+        isNull:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should not include readinessProbe when disabled
+    set:
+      clickhouse:
+        enabled: true
+        readinessProbe:
+          enabled: false
+    asserts:
+      - documentIndex: 0
+        isNull:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should use custom livenessProbe values when provided
+    set:
+      clickhouse:
+        enabled: true
+        port: 8123
+        livenessProbe:
+          enabled: true
+          initialDelaySeconds: 20
+          periodSeconds: 60
+          timeoutSeconds: 10
+          failureThreshold: 5
+    asserts:
+      - documentIndex: 0
+        isSubset:
+          path: spec.template.spec.containers[0].livenessProbe
+          content:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 20
+            periodSeconds: 60
+            timeoutSeconds: 10
+            failureThreshold: 5
+
+  - it: should use custom readinessProbe values when provided
+    set:
+      clickhouse:
+        enabled: true
+        port: 8123
+        readinessProbe:
+          enabled: true
+          initialDelaySeconds: 5
+          periodSeconds: 20
+          timeoutSeconds: 3
+          failureThreshold: 2
+    asserts:
+      - documentIndex: 0
+        isSubset:
+          path: spec.template.spec.containers[0].readinessProbe
+          content:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 5
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 2
 
   - it: should use custom port in probes when provided
     set:

--- a/charts/hdx-oss-v2/tests/hyperdx-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/hyperdx-deployment_test.yaml
@@ -129,3 +129,41 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "until nc -z .+-mongodb [0-9]+; do echo waiting for mongodb; sleep 2; done;"
+
+  - it: should include livenessProbe with default values
+    asserts:
+      - isSubset:
+          path: spec.template.spec.containers[0].livenessProbe
+          content:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+  - it: should include readinessProbe with default values
+    asserts:
+      - isSubset:
+          path: spec.template.spec.containers[0].readinessProbe
+          content:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+  - it: should use custom apiPort in probes when provided
+    set:
+      hyperdx:
+        apiPort: 9000
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 9000
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 9000

--- a/charts/hdx-oss-v2/tests/hyperdx-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/hyperdx-deployment_test.yaml
@@ -130,7 +130,7 @@ tests:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "until nc -z .+-mongodb [0-9]+; do echo waiting for mongodb; sleep 2; done;"
 
-  - it: should include livenessProbe with default values
+  - it: should include livenessProbe with default values when enabled
     asserts:
       - isSubset:
           path: spec.template.spec.containers[0].livenessProbe
@@ -143,7 +143,7 @@ tests:
             timeoutSeconds: 5
             failureThreshold: 3
 
-  - it: should include readinessProbe with default values
+  - it: should include readinessProbe with default values when enabled
     asserts:
       - isSubset:
           path: spec.template.spec.containers[0].readinessProbe
@@ -155,6 +155,66 @@ tests:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+
+  - it: should not include livenessProbe when disabled
+    set:
+      hyperdx:
+        livenessProbe:
+          enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should not include readinessProbe when disabled
+    set:
+      hyperdx:
+        readinessProbe:
+          enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should use custom livenessProbe values when provided
+    set:
+      hyperdx:
+        livenessProbe:
+          enabled: true
+          initialDelaySeconds: 20
+          periodSeconds: 60
+          timeoutSeconds: 10
+          failureThreshold: 5
+    asserts:
+      - isSubset:
+          path: spec.template.spec.containers[0].livenessProbe
+          content:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 20
+            periodSeconds: 60
+            timeoutSeconds: 10
+            failureThreshold: 5
+
+  - it: should use custom readinessProbe values when provided
+    set:
+      hyperdx:
+        readinessProbe:
+          enabled: true
+          initialDelaySeconds: 5
+          periodSeconds: 20
+          timeoutSeconds: 3
+          failureThreshold: 2
+    asserts:
+      - isSubset:
+          path: spec.template.spec.containers[0].readinessProbe
+          content:
+            httpGet:
+              path: /health
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 2
 
   - it: should use custom apiPort in probes when provided
     set:

--- a/charts/hdx-oss-v2/tests/mongodb-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/mongodb-deployment_test.yaml
@@ -72,7 +72,7 @@ tests:
         isNull:
           path: spec.template.spec.volumes[0].persistentVolumeClaim
 
-  - it: should include livenessProbe with exec command
+  - it: should include livenessProbe with tcpSocket
     set:
       mongodb:
         enabled: true
@@ -81,17 +81,14 @@ tests:
         isSubset:
           path: spec.template.spec.containers[0].livenessProbe
           content:
-            exec:
-              command:
-                - mongosh
-                - --eval
-                - "db.adminCommand('ping')"
+            tcpSocket:
+              port: 27017
             initialDelaySeconds: 10
             periodSeconds: 30
             timeoutSeconds: 5
             failureThreshold: 3
 
-  - it: should include readinessProbe with exec command
+  - it: should include readinessProbe with tcpSocket
     set:
       mongodb:
         enabled: true
@@ -100,11 +97,8 @@ tests:
         isSubset:
           path: spec.template.spec.containers[0].readinessProbe
           content:
-            exec:
-              command:
-                - mongosh
-                - --eval
-                - "db.adminCommand('ping')"
+            tcpSocket:
+              port: 27017
             initialDelaySeconds: 1
             periodSeconds: 10
             timeoutSeconds: 5

--- a/charts/hdx-oss-v2/tests/mongodb-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/mongodb-deployment_test.yaml
@@ -71,3 +71,41 @@ tests:
       - documentIndex: 0
         isNull:
           path: spec.template.spec.volumes[0].persistentVolumeClaim
+
+  - it: should include livenessProbe with exec command
+    set:
+      mongodb:
+        enabled: true
+    asserts:
+      - documentIndex: 0
+        isSubset:
+          path: spec.template.spec.containers[0].livenessProbe
+          content:
+            exec:
+              command:
+                - mongosh
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+  - it: should include readinessProbe with exec command
+    set:
+      mongodb:
+        enabled: true
+    asserts:
+      - documentIndex: 0
+        isSubset:
+          path: spec.template.spec.containers[0].readinessProbe
+          content:
+            exec:
+              command:
+                - mongosh
+                - --eval
+                - "db.adminCommand('ping')"
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3

--- a/charts/hdx-oss-v2/tests/mongodb-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/mongodb-deployment_test.yaml
@@ -72,7 +72,7 @@ tests:
         isNull:
           path: spec.template.spec.volumes[0].persistentVolumeClaim
 
-  - it: should include livenessProbe with tcpSocket
+  - it: should include livenessProbe with tcpSocket when enabled
     set:
       mongodb:
         enabled: true
@@ -88,7 +88,7 @@ tests:
             timeoutSeconds: 5
             failureThreshold: 3
 
-  - it: should include readinessProbe with tcpSocket
+  - it: should include readinessProbe with tcpSocket when enabled
     set:
       mongodb:
         enabled: true
@@ -103,3 +103,69 @@ tests:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+
+  - it: should not include livenessProbe when disabled
+    set:
+      mongodb:
+        enabled: true
+        livenessProbe:
+          enabled: false
+    asserts:
+      - documentIndex: 0
+        isNull:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should not include readinessProbe when disabled
+    set:
+      mongodb:
+        enabled: true
+        readinessProbe:
+          enabled: false
+    asserts:
+      - documentIndex: 0
+        isNull:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should use custom livenessProbe values when provided
+    set:
+      mongodb:
+        enabled: true
+        livenessProbe:
+          enabled: true
+          initialDelaySeconds: 20
+          periodSeconds: 60
+          timeoutSeconds: 10
+          failureThreshold: 5
+    asserts:
+      - documentIndex: 0
+        isSubset:
+          path: spec.template.spec.containers[0].livenessProbe
+          content:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 20
+            periodSeconds: 60
+            timeoutSeconds: 10
+            failureThreshold: 5
+
+  - it: should use custom readinessProbe values when provided
+    set:
+      mongodb:
+        enabled: true
+        readinessProbe:
+          enabled: true
+          initialDelaySeconds: 5
+          periodSeconds: 20
+          timeoutSeconds: 3
+          failureThreshold: 2
+    asserts:
+      - documentIndex: 0
+        isSubset:
+          path: spec.template.spec.containers[0].readinessProbe
+          content:
+            tcpSocket:
+              port: 27017
+            initialDelaySeconds: 5
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 2

--- a/charts/hdx-oss-v2/tests/otel-collector_test.yaml
+++ b/charts/hdx-oss-v2/tests/otel-collector_test.yaml
@@ -686,3 +686,54 @@ tests:
             checksum/config: "abcdef1234567890"
             deployment.kubernetes.io/revision: "1"
             sidecar.istio.io/inject: "false"
+
+  - it: should include livenessProbe with default values
+    set:
+      otel:
+        enabled: true
+        port: 13133
+    asserts:
+      - documentIndex: 0
+        isSubset:
+          path: spec.template.spec.containers[0].livenessProbe
+          content:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 10
+            periodSeconds: 30
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+  - it: should include readinessProbe with default values
+    set:
+      otel:
+        enabled: true
+        port: 13133
+    asserts:
+      - documentIndex: 0
+        isSubset:
+          path: spec.template.spec.containers[0].readinessProbe
+          content:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 3
+
+  - it: should use custom port in probes when provided
+    set:
+      otel:
+        enabled: true
+        port: 13134
+    asserts:
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.port
+          value: 13134
+      - documentIndex: 0
+        equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 13134

--- a/charts/hdx-oss-v2/tests/otel-collector_test.yaml
+++ b/charts/hdx-oss-v2/tests/otel-collector_test.yaml
@@ -687,7 +687,7 @@ tests:
             deployment.kubernetes.io/revision: "1"
             sidecar.istio.io/inject: "false"
 
-  - it: should include livenessProbe with default values
+  - it: should include livenessProbe with default values when enabled
     set:
       otel:
         enabled: true
@@ -705,7 +705,7 @@ tests:
             timeoutSeconds: 5
             failureThreshold: 3
 
-  - it: should include readinessProbe with default values
+  - it: should include readinessProbe with default values when enabled
     set:
       otel:
         enabled: true
@@ -722,6 +722,76 @@ tests:
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
+
+  - it: should not include livenessProbe when disabled
+    set:
+      otel:
+        enabled: true
+        livenessProbe:
+          enabled: false
+    asserts:
+      - documentIndex: 0
+        isNull:
+          path: spec.template.spec.containers[0].livenessProbe
+
+  - it: should not include readinessProbe when disabled
+    set:
+      otel:
+        enabled: true
+        readinessProbe:
+          enabled: false
+    asserts:
+      - documentIndex: 0
+        isNull:
+          path: spec.template.spec.containers[0].readinessProbe
+
+  - it: should use custom livenessProbe values when provided
+    set:
+      otel:
+        enabled: true
+        port: 13133
+        livenessProbe:
+          enabled: true
+          initialDelaySeconds: 20
+          periodSeconds: 60
+          timeoutSeconds: 10
+          failureThreshold: 5
+    asserts:
+      - documentIndex: 0
+        isSubset:
+          path: spec.template.spec.containers[0].livenessProbe
+          content:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 20
+            periodSeconds: 60
+            timeoutSeconds: 10
+            failureThreshold: 5
+
+  - it: should use custom readinessProbe values when provided
+    set:
+      otel:
+        enabled: true
+        port: 13133
+        readinessProbe:
+          enabled: true
+          initialDelaySeconds: 15
+          periodSeconds: 20
+          timeoutSeconds: 3
+          failureThreshold: 2
+    asserts:
+      - documentIndex: 0
+        isSubset:
+          path: spec.template.spec.containers[0].readinessProbe
+          content:
+            httpGet:
+              path: /
+              port: 13133
+            initialDelaySeconds: 15
+            periodSeconds: 20
+            timeoutSeconds: 3
+            failureThreshold: 2
 
   - it: should use custom port in probes when provided
     set:

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -8,6 +8,18 @@ hyperdx:
     repository: docker.hyperdx.io/hyperdx/hyperdx
     tag:
     pullPolicy: IfNotPresent
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 1
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
   # Add nodeSelector and tolerations for hyperdx service
   nodeSelector: {}
     # Example:
@@ -221,11 +233,35 @@ mongodb:
   persistence:
     enabled: true
     dataSize: 10Gi
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 1
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
 
 clickhouse:
   image: "clickhouse/clickhouse-server:24-alpine"
   port: 8123
   nativePort: 9000
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 1
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
   enabled: true
   # Add nodeSelector and tolerations for clickhouse service
   nodeSelector: {}
@@ -330,6 +366,18 @@ otel:
   clickhousePrometheusEndpoint:
   # Clickhouse database to send logs/traces/metrics to. Defaults to "default"
   clickhouseDatabase: "default"
+  livenessProbe:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 30
+    timeoutSeconds: 5
+    failureThreshold: 3
+  readinessProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 3
 
 tasks:
   enabled: false


### PR DESCRIPTION
Closes HDX-1992

Adds livenessProbe and readinessProbe to mongo, clickhouse, otel-collector, and hyperdx services.

Tested on cluster and chart rendering via
```bash
helm template test ./charts/hdx-oss-v2 --set otel.enabled=true --set clickhouse.enabled=true --set mongodb.enabled=true
```