### PR TITLE
feat: implement safe clickhouse upgrade process + resource limits support

### DIFF
--- a/.changeset/puny-hats-turn.md
+++ b/.changeset/puny-hats-turn.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": minor
+---
+
+feat: implement safe clickhouse upgrade process + resource limits support

--- a/.changeset/shaggy-squids-wonder.md
+++ b/.changeset/shaggy-squids-wonder.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": minor
+---
+
+chore: bump clickhouse to v25.7

--- a/charts/hdx-oss-v2/data/config.xml
+++ b/charts/hdx-oss-v2/data/config.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0"?>
 <clickhouse>
+   <user_directories>
+        <users_xml>
+            <path>/etc/clickhouse-server/users.xml</path>
+        </users_xml>
+    </user_directories>
+
     <logger>
         <level>information</level>
         <console>true</console>

--- a/charts/hdx-oss-v2/data/config.xml
+++ b/charts/hdx-oss-v2/data/config.xml
@@ -33,6 +33,9 @@
     <timezone>UTC</timezone>
     <mlock_executable>false</mlock_executable>
 
+    <!-- Graceful shutdown settings -->
+    <shutdown_wait_unfinished>60</shutdown_wait_unfinished>
+
     {{- if .Values.clickhouse.prometheus.enabled }}
     <!-- Prometheus exporter -->
     <prometheus>

--- a/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
@@ -8,6 +8,8 @@ metadata:
     app: clickhouse
 spec:
   replicas: 1
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       {{- include "hdx-oss.selectorLabels" . | nindent 6 }}
@@ -33,12 +35,28 @@ spec:
       containers:
         - name: clickhouse
           image: "{{ .Values.clickhouse.image }}"
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: {{ .Values.clickhouse.port }}
             - containerPort: {{ .Values.clickhouse.nativePort }}
           env:
             - name: CLICKHOUSE_DEFAULT_ACCESS_MANAGEMENT
               value: "1"
+          {{- if .Values.clickhouse.resources }}
+          resources:
+            {{- toYaml .Values.clickhouse.resources | nindent 12 }}
+          {{- end }}
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - |
+                    clickhouse-client --query "SYSTEM STOP MERGES" || true
+                    clickhouse-client --query "SYSTEM STOP MOVES" || true
+                    clickhouse-client --query "SYSTEM FLUSH LOGS" || true
+                    sleep 5
           {{- if .Values.clickhouse.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
@@ -58,6 +76,16 @@ spec:
             periodSeconds: {{ .Values.clickhouse.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.clickhouse.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.clickhouse.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- if .Values.clickhouse.startupProbe.enabled }}
+          startupProbe:
+            httpGet:
+              path: /ping
+              port: {{ .Values.clickhouse.port }}
+            initialDelaySeconds: {{ .Values.clickhouse.startupProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.clickhouse.startupProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.clickhouse.startupProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.clickhouse.startupProbe.failureThreshold }}
           {{- end }}
           volumeMounts:
             - name: config

--- a/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/clickhouse-deployment.yaml
@@ -20,6 +20,7 @@ spec:
         {{- include "hdx-oss.selectorLabels" . | nindent 8 }}
         app: clickhouse
     spec:
+      terminationGracePeriodSeconds: {{ .Values.clickhouse.terminationGracePeriodSeconds | default 90 }}
       {{- if .Values.clickhouse.nodeSelector }}
       nodeSelector:
         {{- toYaml .Values.clickhouse.nodeSelector | nindent 8 }}

--- a/charts/hdx-oss-v2/tests/clickhouse-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/clickhouse-deployment_test.yaml
@@ -385,3 +385,171 @@ tests:
         equal:
           path: spec.template.spec.imagePullSecrets[0].name
           value: regcred
+
+  - it: should have Recreate deployment strategy
+    set:
+      clickhouse:
+        enabled: true
+    asserts:
+      - documentSelector: *deployment-selector
+        equal:
+          path: spec.strategy.type
+          value: Recreate
+
+  - it: should have imagePullPolicy set to IfNotPresent
+    set:
+      clickhouse:
+        enabled: true
+    asserts:
+      - documentSelector: *deployment-selector
+        equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: IfNotPresent
+
+  - it: should include resources when configured
+    set:
+      clickhouse:
+        enabled: true
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+          limits:
+            memory: "2Gi"
+            cpu: "2000m"
+    asserts:
+      - documentSelector: *deployment-selector
+        equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: "512Mi"
+      - documentSelector: *deployment-selector
+        equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: "500m"
+      - documentSelector: *deployment-selector
+        equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: "2Gi"
+      - documentSelector: *deployment-selector
+        equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "2000m"
+
+  - it: should not include resources when not configured
+    set:
+      clickhouse:
+        enabled: true
+        resources: {}
+    asserts:
+      - documentSelector: *deployment-selector
+        isNull:
+          path: spec.template.spec.containers[0].resources
+
+  - it: should include preStop lifecycle hook with correct commands
+    set:
+      clickhouse:
+        enabled: true
+    asserts:
+      - documentSelector: *deployment-selector
+        isNotNull:
+          path: spec.template.spec.containers[0].lifecycle.preStop
+      - documentSelector: *deployment-selector
+        equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[0]
+          value: /bin/sh
+      - documentSelector: *deployment-selector
+        equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[1]
+          value: -c
+      - documentSelector: *deployment-selector
+        matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: ".*SYSTEM STOP MERGES.*"
+      - documentSelector: *deployment-selector
+        matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: ".*SYSTEM STOP MOVES.*"
+      - documentSelector: *deployment-selector
+        matchRegex:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          pattern: ".*SYSTEM FLUSH LOGS.*"
+
+  - it: should include startupProbe with default values when enabled
+    set:
+      clickhouse:
+        enabled: true
+        port: 8123
+        startupProbe:
+          enabled: true
+          initialDelaySeconds: 5
+          periodSeconds: 10
+          timeoutSeconds: 5
+          failureThreshold: 30
+    asserts:
+      - documentSelector: *deployment-selector
+        isSubset:
+          path: spec.template.spec.containers[0].startupProbe
+          content:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 5
+            periodSeconds: 10
+            timeoutSeconds: 5
+            failureThreshold: 30
+
+  - it: should not include startupProbe when disabled
+    set:
+      clickhouse:
+        enabled: true
+        startupProbe:
+          enabled: false
+    asserts:
+      - documentSelector: *deployment-selector
+        isNull:
+          path: spec.template.spec.containers[0].startupProbe
+
+  - it: should use custom startupProbe values when provided
+    set:
+      clickhouse:
+        enabled: true
+        port: 8123
+        startupProbe:
+          enabled: true
+          initialDelaySeconds: 10
+          periodSeconds: 15
+          timeoutSeconds: 10
+          failureThreshold: 60
+    asserts:
+      - documentSelector: *deployment-selector
+        isSubset:
+          path: spec.template.spec.containers[0].startupProbe
+          content:
+            httpGet:
+              path: /ping
+              port: 8123
+            initialDelaySeconds: 10
+            periodSeconds: 15
+            timeoutSeconds: 10
+            failureThreshold: 60
+
+  - it: should have default terminationGracePeriodSeconds of 90
+    set:
+      clickhouse:
+        enabled: true
+    asserts:
+      - documentSelector: *deployment-selector
+        equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 90
+
+  - it: should use custom terminationGracePeriodSeconds when provided
+    set:
+      clickhouse:
+        enabled: true
+        terminationGracePeriodSeconds: 120
+    asserts:
+      - documentSelector: *deployment-selector
+        equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 120

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -286,6 +286,15 @@ clickhouse:
   image: "clickhouse/clickhouse-server:25.7-alpine"
   port: 8123
   nativePort: 9000
+  resources:
+    {}
+    # Example:
+    # requests:
+    #   memory: "512Mi"
+    #   cpu: "500m"
+    # limits:
+    #   memory: "2Gi"
+    #   cpu: "2000m"
   livenessProbe:
     enabled: true
     initialDelaySeconds: 10
@@ -298,6 +307,12 @@ clickhouse:
     periodSeconds: 10
     timeoutSeconds: 5
     failureThreshold: 3
+  startupProbe:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
+    timeoutSeconds: 5
+    failureThreshold: 30
   enabled: true
   # Add nodeSelector and tolerations for clickhouse service
   nodeSelector:

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -29,11 +29,13 @@ hyperdx:
     timeoutSeconds: 5
     failureThreshold: 3
   # Add nodeSelector and tolerations for hyperdx service
-  nodeSelector: {}
+  nodeSelector:
+    {}
     # Example:
     # kubernetes.io/os: linux
     # node-role.kubernetes.io/worker: "true"
-  tolerations: []
+  tolerations:
+    []
     # Example:
     # - key: "key1"
     #   operator: "Equal"
@@ -55,19 +57,22 @@ hyperdx:
   mongoUri: mongodb://{{ include "hdx-oss.fullname" . }}-mongodb:{{ .Values.mongodb.port }}/hyperdx
 
   # Pod-level annotations (applied to the deployment pods)
-  annotations: {}
+  annotations:
+    {}
     # myAnnotation: "myValue"
 
   # Pod-level labels (applied to the deployment pods)
-  labels: {}
+  labels:
+    {}
     # myLabel: "myValue"
-  env: []
+  env:
+    []
     # Additional environment variables can be configured here
     # This is preserved for backward compatibility and advanced use cases
 
   # Default connections and sources (ENABLED BY DEFAULT)
   # Set to empty string to disable: defaultConnections: "" or defaultSources: ""
-  # 
+  #
   # To use an existing secret instead of inline configuration, set:
   # useExistingConfigSecret: true
   # existingConfigSecret: "my-hyperdx-config"
@@ -79,7 +84,7 @@ hyperdx:
   existingConfigSecret: ""
   existingConfigConnectionsKey: "connections.json"
   existingConfigSourcesKey: "sources.json"
-  
+
   defaultConnections: |
     [
       {
@@ -200,7 +205,7 @@ hyperdx:
     ingressClassName: nginx
     annotations: {}
     # The host to use for the ingress. Defaults to localhost. Be sure to update hyperdx.frontendUrl with this host value + protocol
-    host: "localhost"  # Production domain
+    host: "localhost" # Production domain
     path: "/(.*)"
     pathType: "ImplementationSpecific"
     proxyBodySize: "100m"
@@ -236,9 +241,10 @@ hyperdx:
 
   # Service configuration
   service:
-    type: ClusterIP  # Use ClusterIP for security. For external access, use ingress with proper TLS and authentication
+    type: ClusterIP # Use ClusterIP for security. For external access, use ingress with proper TLS and authentication
     # Service-level annotations (applied to the Kubernetes service resource)
-    annotations: {}
+    annotations:
+      {}
       # Example service annotations:
       # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
       # cloud.google.com/load-balancer-type: "Internal"
@@ -248,11 +254,13 @@ mongodb:
   port: 27017
   enabled: true
   # Add nodeSelector and tolerations for mongodb service
-  nodeSelector: {}
+  nodeSelector:
+    {}
     # Example:
     # kubernetes.io/os: linux
     # node-role.kubernetes.io/worker: "true"
-  tolerations: []
+  tolerations:
+    []
     # Example:
     # - key: "key1"
     #   operator: "Equal"
@@ -275,7 +283,7 @@ mongodb:
     failureThreshold: 3
 
 clickhouse:
-  image: "clickhouse/clickhouse-server:24-alpine"
+  image: "clickhouse/clickhouse-server:25.7-alpine"
   port: 8123
   nativePort: 9000
   livenessProbe:
@@ -292,11 +300,13 @@ clickhouse:
     failureThreshold: 3
   enabled: true
   # Add nodeSelector and tolerations for clickhouse service
-  nodeSelector: {}
+  nodeSelector:
+    {}
     # Example:
     # kubernetes.io/os: linux
     # node-role.kubernetes.io/worker: "true"
-  tolerations: []
+  tolerations:
+    []
     # Example:
     # - key: "key1"
     #   operator: "Equal"
@@ -305,9 +315,10 @@ clickhouse:
 
   # Service configuration
   service:
-    type: ClusterIP  # Use ClusterIP for security. For external access, use ingress with proper TLS and authentication
+    type: ClusterIP # Use ClusterIP for security. For external access, use ingress with proper TLS and authentication
     # Service-level annotations (applied to the Kubernetes service resource)
-    annotations: {}
+    annotations:
+      {}
       # Example service annotations:
       # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
       # cloud.google.com/load-balancer-type: "Internal"
@@ -330,9 +341,9 @@ clickhouse:
     # For PRODUCTION: Remove development CIDRs and keep only your cluster's specific CIDR
     # For DEVELOPMENT: Multiple common CIDRs are included for convenience
     clusterCidrs:
-      - "10.0.0.0/8"        # Most Kubernetes clusters (including GKE, EKS, AKS)
-      - "172.16.0.0/12"     # Some cloud providers and Docker Desktop
-      - "192.168.0.0/16"    # OrbStack, Minikube, and local development
+      - "10.0.0.0/8" # Most Kubernetes clusters (including GKE, EKS, AKS)
+      - "172.16.0.0/12" # Some cloud providers and Docker Desktop
+      - "192.168.0.0/16" # OrbStack, Minikube, and local development
 
 otel:
   image:
@@ -340,7 +351,8 @@ otel:
     tag:
     pullPolicy: IfNotPresent
   replicas: 1
-  resources: {}
+  resources:
+    {}
     # Example:
     # requests:
     #   memory: "127Mi"
@@ -349,14 +361,17 @@ otel:
     #   memory: "256Mi"
     #   cpu: "200m"
   # Pod-level annotations (applied to the deployment pods)
-  annotations: {}
+  annotations:
+    {}
     # myAnnotation: "myValue"
   # Add nodeSelector and tolerations for otel-collector service
-  nodeSelector: {}
+  nodeSelector:
+    {}
     # Example:
     # kubernetes.io/os: linux
     # node-role.kubernetes.io/worker: "true"
-  tolerations: []
+  tolerations:
+    []
     # Example:
     # - key: "key1"
     #   operator: "Equal"
@@ -368,7 +383,8 @@ otel:
   httpPort: 4318
   healthPort: 8888
   enabled: true
-  env: []
+  env:
+    []
     # Additional environment variables can be configured here
     # Example:
     # - name: CUSTOM_VAR
@@ -430,7 +446,7 @@ otel:
 tasks:
   enabled: false
   checkAlerts:
-    schedule: "*/1 * * * *"  # Runs every 1 minute
+    schedule: "*/1 * * * *" # Runs every 1 minute
     resources:
       limits:
         cpu: 200m

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -286,6 +286,7 @@ clickhouse:
   image: "clickhouse/clickhouse-server:25.7-alpine"
   port: 8123
   nativePort: 9000
+  terminationGracePeriodSeconds: 90
   resources:
     {}
     # Example:


### PR DESCRIPTION
- Recreate deployment strategy: Ensures old pod terminates completely before new one starts, preventing multiple pods from accessing the same persistent volume
- imagePullPolicy: IfNotPresent: Consistent image pull behavior
- Resource limits support: Allows users to configure CPU/memory to prevent OOM kills
- Enhanced preStop hook:
  includes:
    - SYSTEM STOP MOVES - Stops data movement between disks
    - SYSTEM STOP MERGES - Stops background merge operations
    - SYSTEM FLUSH DISTRIBUTED - Flushes pending distributed table data
    - SYSTEM FLUSH LOGS - Flushes buffered logs to system tables
    - 5-second grace period before SIGTERM
- startupProbe: Gives up to 5 minutes (30 failures × 10s) for ClickHouse to start, crucial for upgrades with schema migrations
- shutdown_wait_unfinished:  60: This gives ClickHouse 60 seconds to wait for active connections to close gracefully before forcing shutdown
- Bumping default clickhouse version to `v25.7`

Ref: HDX-2569