### PR TITLE
Parameterize hyperdx-deployment initContainer image and pullPolicy

### DIFF
--- a/.changeset/slow-dolls-search.md
+++ b/.changeset/slow-dolls-search.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+refactor: Parameterize hyperdx-deployment initContainer image and pullPolicy

--- a/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
@@ -50,8 +50,8 @@ spec:
       {{- if .Values.mongodb.enabled }}
       initContainers:
         - name: wait-for-mongodb
-          image: "busybox@sha256:1fcf5df59121b92d61e066df1788e8df0cc35623f5d62d9679a41e163b6a0cdb"
-          imagePullPolicy: IfNotPresent
+          image: {{ .Values.hyperdx.waitForMongodb.image }}
+          imagePullPolicy: {{ .Values.hyperdx.waitForMongodb.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "hdx-oss.fullname" . }}-mongodb {{ .Values.mongodb.port }}; do echo waiting for mongodb; sleep 2; done;']
       {{- end }}
       containers:

--- a/charts/hdx-oss-v2/tests/hyperdx-deployment_test.yaml
+++ b/charts/hdx-oss-v2/tests/hyperdx-deployment_test.yaml
@@ -120,6 +120,9 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].image
           value: busybox@sha256:1fcf5df59121b92d61e066df1788e8df0cc35623f5d62d9679a41e163b6a0cdb
+      - equal:
+          path: spec.template.spec.initContainers[0].imagePullPolicy
+          value: IfNotPresent
       - contains:
           path: spec.template.spec.initContainers[0].command
           content: sh
@@ -129,6 +132,22 @@ tests:
       - matchRegex:
           path: spec.template.spec.initContainers[0].command[2]
           pattern: "until nc -z .+-mongodb [0-9]+; do echo waiting for mongodb; sleep 2; done;"
+
+  - it: should allow overriding initContainer image and pullPolicy
+    set:
+      mongodb:
+        enabled: true
+      hyperdx:
+        waitForMongodb:
+          image: busybox:1.36.1
+          pullPolicy: Always
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: busybox:1.36.1
+      - equal:
+          path: spec.template.spec.initContainers[0].imagePullPolicy
+          value: Always
 
   - it: should include livenessProbe with default values when enabled
     asserts:

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -16,6 +16,10 @@ hyperdx:
     repository: docker.hyperdx.io/hyperdx/hyperdx
     tag:
     pullPolicy: IfNotPresent
+  waitForMongodb:
+    # Image used by the init container that waits for MongoDB to be reachable.
+    image: "busybox@sha256:1fcf5df59121b92d61e066df1788e8df0cc35623f5d62d9679a41e163b6a0cdb"
+    pullPolicy: IfNotPresent
   livenessProbe:
     enabled: true
     initialDelaySeconds: 10


### PR DESCRIPTION
  Update the chart template to make the wait-for-mongodb initContainer image and pullPolicy configurable via values.