### PR TITLE
allow users to specify their anthropic api key

### DIFF
--- a/.changeset/poor-worms-wave.md
+++ b/.changeset/poor-worms-wave.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+Add support for ANTHROPIC_API_KEY

--- a/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
@@ -98,6 +98,11 @@ spec:
                 secretKeyRef:
                   name: {{ include "hdx-oss.fullname" . }}-app-secrets
                   key: api-key
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ include "hdx-oss.fullname" . }}-app-secrets
+                  key: anthropic-api-key
             {{- if .Values.hyperdx.useExistingConfigSecret }}
             - name: DEFAULT_CONNECTIONS
               valueFrom:

--- a/charts/hdx-oss-v2/templates/secrets.yaml
+++ b/charts/hdx-oss-v2/templates/secrets.yaml
@@ -7,6 +7,9 @@ metadata:
 type: Opaque
 data:
   api-key: {{ .Values.hyperdx.apiKey | b64enc }}
+ {{- if .Values.hyperdx.anthropicApiKey }}
+  anthropic-api-key: {{ .Values.hyperdx.anthropicApiKey | toString | b64enc }}
+  {{- end }}
 {{- if .Values.clickhouse.enabled }}
 ---
 apiVersion: v1


### PR DESCRIPTION
In HyperDX we added support for AI Assistant in the Graph Explorer. This allows users to pass in an anthropic api key to use this feature from the helm deployment

@teeohhem assigning to you since it says you edited these files recently.. Happy to assign to someone else if needed!

Fixes HDX-2725