### PR TITLE
fix(alerts): update cronjob template to account for different code builds

### DIFF
--- a/.changeset/cuddly-papayas-give.md
+++ b/.changeset/cuddly-papayas-give.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+Fixes the alert cron job template so newer version image tags will use the updated command to start the task.

--- a/charts/hdx-oss-v2/templates/cronjobs/task-checkAlerts.yaml
+++ b/charts/hdx-oss-v2/templates/cronjobs/task-checkAlerts.yaml
@@ -26,7 +26,12 @@ spec:
             - name: task
               image: "{{ .Values.hyperdx.image.repository }}:{{ .Values.hyperdx.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.hyperdx.image.pullPolicy }}
+              {{- $tag := .Values.hyperdx.image.tag | default .Chart.AppVersion -}}
+              {{- if and (regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+" $tag) (semverCompare "< 2.7.1" $tag) }} # before esbuild revert
               command: ["node", "/app/packages/api/tasks/index", "check-alerts"]
+              {{- else }}
+              command: ["node", "/app/api/build/tasks/index.js", "check-alerts"] # after esbuild revert
+              {{- end }}
               envFrom:
                 - configMapRef:
                     name: {{ include "hdx-oss.fullname" . }}-app-config

--- a/charts/hdx-oss-v2/tests/task-checkAlerts_test.yaml
+++ b/charts/hdx-oss-v2/tests/task-checkAlerts_test.yaml
@@ -9,7 +9,7 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
-          
+
   - it: should render correctly when tasks are enabled
     set:
       tasks:
@@ -24,7 +24,7 @@ tests:
               cpu: 150m
               memory: 150Mi
       hyperdx:
-        image: 
+        image:
           repository: hyperdx/hyperdx
           tag: 2-beta
     asserts:
@@ -38,7 +38,7 @@ tests:
           value: hyperdx/hyperdx:2-beta
       - equal:
           path: spec.jobTemplate.spec.template.spec.containers[0].command
-          value: ["node", "/app/packages/api/tasks/index", "check-alerts"]
+          value: ["node", "/app/api/build/tasks/index.js", "check-alerts"]
       - isSubset:
           path: spec.jobTemplate.spec.template.spec.containers[0].resources
           content:
@@ -63,7 +63,7 @@ tests:
           content:
             name: OTEL_SERVICE_NAME
             value: "hdx-oss-task-check-alerts"
-            
+
   - it: should use default schedule when not provided
     set:
       tasks:
@@ -94,3 +94,63 @@ tests:
       - equal:
           path: spec.jobTemplate.spec.template.spec.imagePullSecrets[0].name
           value: regcred
+
+  - it: should use esbuild command path for versions before 2.7.1
+    set:
+      tasks:
+        enabled: true
+      hyperdx:
+        image:
+          tag: "2.7.0"
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          value: ["node", "/app/packages/api/tasks/index", "check-alerts"]
+
+  - it: should use esbuild command path for version 2.6.0
+    set:
+      tasks:
+        enabled: true
+      hyperdx:
+        image:
+          tag: "2.6.0"
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          value: ["node", "/app/packages/api/tasks/index", "check-alerts"]
+
+  - it: should use post-esbuild command path for version 2.7.1
+    set:
+      tasks:
+        enabled: true
+      hyperdx:
+        image:
+          tag: "2.7.1"
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          value: ["node", "/app/api/build/tasks/index.js", "check-alerts"]
+
+  - it: should use post-esbuild command path for versions after 2.7.1
+    set:
+      tasks:
+        enabled: true
+      hyperdx:
+        image:
+          tag: "2.8.0"
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          value: ["node", "/app/api/build/tasks/index.js", "check-alerts"]
+
+  - it: should use post-esbuild command path for version 3.0.0
+    set:
+      tasks:
+        enabled: true
+      hyperdx:
+        image:
+          tag: "3.0.0"
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].command
+          value: ["node", "/app/api/build/tasks/index.js", "check-alerts"]


### PR DESCRIPTION
In HyperDX 2.7.1, the way in which the typescript code is built and packaged changed, which changes the command required to start the cron job. This commit updates the template such that:

  * versions before 2.7.1 should continue to use the esbuild command to run the cron job.

  * versions 2.7.1+ or non-semver tags, e.g. 2-nightly) will use the updated non-esbuild command to run the job.