### PR TITLE
add hostalias

### DIFF
--- a/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
+++ b/charts/hdx-oss-v2/templates/hyperdx-deployment.yaml
@@ -54,6 +54,10 @@ spec:
           imagePullPolicy: {{ .Values.hyperdx.waitForMongodb.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "hdx-oss.fullname" . }}-mongodb {{ .Values.mongodb.port }}; do echo waiting for mongodb; sleep 2; done;']
       {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: app
           image: "{{ .Values.hyperdx.image.repository }}:{{ .Values.hyperdx.image.tag | default .Chart.AppVersion }}"


### PR DESCRIPTION
i use clickhouse cloud as storage.

i want to use aws private link to insert data to clickhouse cloud via internal network.

i want to add dns resolve from service's dns record to aws vpc endpoint ip。

see https://clickhouse.com/docs/manage/security/aws-privatelink#set-private-dns-name-for-endpoint

use hostalias to do this.

example:
```
hostAliases:
  - ip: "xxx"
    hostnames:
      - "ryxwcaao6f.ap-southeast-1.vpce.aws.clickhouse.cloud"
```