### PR TITLE
chore: bump MongoDB version to 5.0.32

### DIFF
--- a/.changeset/tame-bees-tickle.md
+++ b/.changeset/tame-bees-tickle.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+chore: bump MongoDB version to 5.0.32

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -254,7 +254,7 @@ hyperdx:
       # cloud.google.com/load-balancer-type: "Internal"
 
 mongodb:
-  image: "mongo:5.0.14-focal"
+  image: "mongo:5.0.32-focal"
   port: 27017
   enabled: true
   # Add nodeSelector and tolerations for mongodb service

--- a/charts/hdx-oss-v2/values.yaml
+++ b/charts/hdx-oss-v2/values.yaml
@@ -254,7 +254,7 @@ hyperdx:
       # cloud.google.com/load-balancer-type: "Internal"
 
 mongodb:
-  image: "mongo:5.0.14-focal"
+  image: "mongo:5.0.32-focal"
   port: 27017
   enabled: true
   # Add nodeSelector and tolerations for mongodb service


### PR DESCRIPTION
For the patch of https://github.com/advisories/GHSA-4742-mr57-2r9j