### PR TITLE
feat: overridable mongodb strategy

### DIFF
--- a/charts/clickstack/templates/mongodb-deployment.yaml
+++ b/charts/clickstack/templates/mongodb-deployment.yaml
@@ -34,6 +34,10 @@ spec:
     matchLabels:
       {{- include "clickstack.selectorLabels" . | nindent 6 }}
       app: mongodb
+  {{- if .Values.mongodb.strategy }}
+  strategy:
+    {{- toYaml .Values.mongodb.strategy | nindent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/clickstack/tests/mongodb-deployment_test.yaml
+++ b/charts/clickstack/tests/mongodb-deployment_test.yaml
@@ -30,8 +30,8 @@ tests:
           of: Deployment
       - documentSelector: *service-selector
         isKind:
-          of: Service 
-  
+          of: Service
+
   - it: should not render any documents when disabled
     set:
       mongodb:
@@ -302,3 +302,18 @@ tests:
         equal:
           path: spec.template.spec.imagePullSecrets[0].name
           value: regcred
+
+  - it: should include strategy when configured
+    set:
+      mongodb:
+        enabled: true
+        strategy:
+          type: Recreate
+    asserts:
+      - documentIndex: 1
+        isNotNull:
+          path: spec.strategy
+      - documentIndex: 1
+        equal:
+          path: spec.strategy.type
+          value: Recreate

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -257,6 +257,12 @@ mongodb:
   image: "mongo:5.0.32-focal"
   port: 27017
   enabled: true
+  # Optionally override rollout strategy with type=Recreate
+  # to avoid mongodb image update issues
+  # when newer instance cannot start
+  # because older one holds /data/db/mongod.lock
+  # at a cost of short mongodb downtime.
+  strategy: null
   # Add nodeSelector and tolerations for mongodb service
   nodeSelector:
     {}


### PR DESCRIPTION
Address https://github.com/ClickHouse/ClickStack-helm-charts/issues/175

This PR adds new `mongodb.strategy` option, fully optional.

values.yaml comment can be too verbose, open to suggestions.