### PR TITLE
Add kubernetes recommended labels to all resources

### DIFF
--- a/charts/clickstack/templates/_helpers.tpl
+++ b/charts/clickstack/templates/_helpers.tpl
@@ -38,6 +38,7 @@ helm.sh/chart: {{ include "clickstack.chart" . }}
 app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: clickstack
 {{- end }}
 
 {{/*
@@ -46,4 +47,4 @@ Selector labels
 {{- define "clickstack.selectorLabels" -}}
 app.kubernetes.io/name: {{ include "clickstack.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
-{{- end }} 
+{{- end }}

--- a/charts/clickstack/templates/clickhouse-deployment.yaml
+++ b/charts/clickstack/templates/clickhouse-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-clickhouse
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
     app: clickhouse
 spec:
   replicas: 1
@@ -18,6 +19,7 @@ spec:
     metadata:
       labels:
         {{- include "clickstack.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: clickhouse
         app: clickhouse
     spec:
       terminationGracePeriodSeconds: {{ .Values.clickhouse.terminationGracePeriodSeconds | default 90 }}
@@ -127,6 +129,8 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-clickhouse
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+    app: clickhouse
   {{- if .Values.clickhouse.service.annotations }}
   annotations:
     {{- with .Values.clickhouse.service.annotations }}
@@ -157,6 +161,8 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-clickhouse-config
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+    app: clickhouse
 data:
   config.xml: |-
     {{- tpl (.Files.Get "data/config.xml") . | nindent 4 }}
@@ -168,6 +174,8 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-clickhouse-users
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+    app: clickhouse
 data:
   users.xml: |-
     {{- tpl (.Files.Get "data/users.xml") . | nindent 4 }}
@@ -180,6 +188,8 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-clickhouse-data
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+    app: clickhouse
   {{- if .Values.global.keepPVC }}
   annotations:
     "helm.sh/resource-policy": keep
@@ -200,6 +210,8 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-clickhouse-logs
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
+    app: clickhouse
   {{- if .Values.global.keepPVC }}
   annotations:
     "helm.sh/resource-policy": keep

--- a/charts/clickstack/templates/configmaps/app-configmap.yaml
+++ b/charts/clickstack/templates/configmaps/app-configmap.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-app-config
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: workload
 data:
   APP_PORT: {{ .Values.hyperdx.appPort | quote }}
   API_PORT: {{ .Values.hyperdx.apiPort | quote }}

--- a/charts/clickstack/templates/configmaps/otel-collector-configmap.yaml
+++ b/charts/clickstack/templates/configmaps/otel-collector-configmap.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-otel-custom-config
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: opentelemetry
     app: otel-collector
 data:
   custom.config.yaml: |

--- a/charts/clickstack/templates/cronjobs/task-checkAlerts.yaml
+++ b/charts/clickstack/templates/cronjobs/task-checkAlerts.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-check-alerts
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: workflow
 spec:
   schedule: {{ .Values.tasks.checkAlerts.schedule | quote }}
   concurrencyPolicy: Forbid

--- a/charts/clickstack/templates/hyperdx-deployment.yaml
+++ b/charts/clickstack/templates/hyperdx-deployment.yaml
@@ -4,10 +4,11 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-app
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hyperdx
     app: {{ include "clickstack.fullname" . }}
     {{- if .Values.hyperdx.labels }}
     {{- with .Values.hyperdx.labels }}
-    {{- toYaml . | nindent 4 }} 
+    {{- toYaml . | nindent 4 }}
     {{- end -}}
     {{- end }}
 spec:
@@ -20,11 +21,12 @@ spec:
     metadata:
       labels:
         {{- include "clickstack.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: hyperdx
         app: {{ include "clickstack.fullname" . }}
       annotations:
       {{- if .Values.hyperdx.annotations }}
         {{- with .Values.hyperdx.annotations }}
-        {{- toYaml . | nindent 8 }} 
+        {{- toYaml . | nindent 8 }}
         {{- end -}}
       {{- end }}
     spec:

--- a/charts/clickstack/templates/hyperdx-pdb.yaml
+++ b/charts/clickstack/templates/hyperdx-pdb.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-pdb
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hyperdx
     app: {{ include "clickstack.fullname" . }}
     {{- if .Values.hyperdx.labels }}
     {{- with .Values.hyperdx.labels }}

--- a/charts/clickstack/templates/hyperdx-service.yaml
+++ b/charts/clickstack/templates/hyperdx-service.yaml
@@ -4,6 +4,8 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-app
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hyperdx
+    app: {{ include "clickstack.fullname" . }}
   {{- if .Values.hyperdx.service.annotations }}
   annotations:
     {{- with .Values.hyperdx.service.annotations }}

--- a/charts/clickstack/templates/ingress.yaml
+++ b/charts/clickstack/templates/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-app-ingress
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hyperdx
   annotations:
     {{ $reqAnnotations := dict }}
     {{- if eq .Values.hyperdx.ingress.ingressClassName "nginx" }}
@@ -48,6 +49,7 @@ metadata:
   name: {{ printf "%s-%s" (include "clickstack.fullname" $) .name }}
   labels:
     {{- include "clickstack.labels" $ | nindent 4 }}
+    app.kubernetes.io/component: hyperdx
   {{- if .annotations }}
   {{- if not (kindIs "map" .annotations) }}
   {{- fail "annotations must be a map of string key-value pairs" }}

--- a/charts/clickstack/templates/mongodb-deployment.yaml
+++ b/charts/clickstack/templates/mongodb-deployment.yaml
@@ -6,6 +6,8 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-mongodb
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+    app: mongodb
   {{- if .Values.global.keepPVC }}
   annotations:
     "helm.sh/resource-policy": keep
@@ -27,6 +29,7 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-mongodb
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
     app: mongodb
 spec:
   replicas: 1
@@ -42,6 +45,7 @@ spec:
     metadata:
       labels:
         {{- include "clickstack.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: mongodb
         app: mongodb
     spec:
       {{- if .Values.mongodb.nodeSelector }}
@@ -97,6 +101,8 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-mongodb
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: mongodb
+    app: mongodb
 spec:
   ports:
     - port: {{ .Values.mongodb.port }}

--- a/charts/clickstack/templates/otel-collector-deployment.yaml
+++ b/charts/clickstack/templates/otel-collector-deployment.yaml
@@ -5,6 +5,7 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-otel-collector
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: opentelemetry
     app: otel-collector
 spec:
   replicas: {{ .Values.otel.replicas | default 1 }}
@@ -16,6 +17,7 @@ spec:
     metadata:
       labels:
         {{- include "clickstack.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: opentelemetry
         app: otel-collector
       annotations:
       {{- if .Values.otel.annotations }}
@@ -121,6 +123,8 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-otel-collector
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: opentelemetry
+    app: otel-collector
 spec:
   ports:
     - port: {{ .Values.otel.port }}

--- a/charts/clickstack/templates/secrets.yaml
+++ b/charts/clickstack/templates/secrets.yaml
@@ -4,6 +4,7 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-app-secrets
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: hyperdx
 type: Opaque
 data:
   api-key: {{ .Values.hyperdx.apiKey | b64enc }}
@@ -15,6 +16,7 @@ metadata:
   name: {{ include "clickstack.fullname" . }}-clickhouse-secrets
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
+    app.kubernetes.io/component: clickhouse
 type: Opaque
 data:
   appUserPassword: {{ .Values.clickhouse.config.users.appUserPassword | toString | b64enc }}


### PR DESCRIPTION
Add `app.kubernetes.io/component` and `app.kubernetes.io/part-of` labels across all Kubernetes resources to follow recommended labeling conventions.