### PR TITLE
fix(build): make the nightly build version tag allowed

### DIFF
--- a/charts/clickstack/tests/helpers_test.yaml
+++ b/charts/clickstack/tests/helpers_test.yaml
@@ -46,4 +46,4 @@ tests:
     asserts:
       - matchRegex:
           path: metadata.labels["app.kubernetes.io/version"]
-          pattern: ^\d+\.\d+\.\d+$
+          pattern: ^(\d+\.\d+\.\d+|\d+-nightly)$

--- a/charts/clickstack/tests/hyperdx-deployment_test.yaml
+++ b/charts/clickstack/tests/hyperdx-deployment_test.yaml
@@ -11,7 +11,7 @@ tests:
           value: 1
       - matchRegex:
           path: spec.template.spec.containers[0].image
-          pattern: ^docker\.hyperdx\.io/hyperdx/hyperdx:\d+\.\d+\.\d+$
+          pattern: ^docker\.hyperdx\.io/hyperdx/hyperdx:(\d+\.\d+\.\d+|\d+-nightly)$
       - equal:
           path: spec.template.spec.containers[0].ports[0].containerPort
           value: 3000

--- a/charts/clickstack/tests/ingress_test.yaml
+++ b/charts/clickstack/tests/ingress_test.yaml
@@ -295,7 +295,7 @@ tests:
         documentSelector: *otel-collector-ingress-selector
       - matchRegex:
           path: metadata.labels["app.kubernetes.io/version"]
-          pattern: ^\d+\.\d+\.\d+$
+          pattern: ^(\d+\.\d+\.\d+|\d+-nightly)$
         documentSelector: *otel-collector-ingress-selector
 
   - it: should render additional ingress templates with TLS enabled
@@ -398,7 +398,7 @@ tests:
         documentSelector: *otel-collector-ingress-selector
       - matchRegex:
           path: metadata.labels["app.kubernetes.io/version"]
-          pattern: ^\d+\.\d+\.\d+$
+          pattern: ^(\d+\.\d+\.\d+|\d+-nightly)$
         documentSelector: *otel-collector-ingress-selector
 
   - it: should fail when annotations of the additional ingresses is not a map of strings

--- a/charts/clickstack/tests/secrets_test.yaml
+++ b/charts/clickstack/tests/secrets_test.yaml
@@ -85,7 +85,7 @@ tests:
         documentSelector: *app-secrets-selector
       - matchRegex:
           path: metadata.labels["app.kubernetes.io/version"]
-          pattern: ^\d+\.\d+\.\d+$
+          pattern: ^(\d+\.\d+\.\d+|\d+-nightly)$
         documentSelector: *app-secrets-selector
       - isSubset:
           path: metadata.labels
@@ -96,7 +96,7 @@ tests:
         documentSelector: *clickhouse-secrets-selector
       - matchRegex:
           path: metadata.labels["app.kubernetes.io/version"]
-          pattern: ^\d+\.\d+\.\d+$
+          pattern: ^(\d+\.\d+\.\d+|\d+-nightly)$
         documentSelector: *clickhouse-secrets-selector
       # Validate chart version format without exact match
       - matchRegex:


### PR DESCRIPTION
Updates the regex rules to allow nightly build tags like 2-nightly so the nightly actions are able to run.