### PR TITLE
ci: add OpenTelemetry tracing to chart integration test workflow

### DIFF
--- a/.github/workflows/chart-test.yml
+++ b/.github/workflows/chart-test.yml
@@ -192,7 +192,7 @@ jobs:
       - name: Export workflow
         uses: corentinmusard/otel-cicd-action@v4
         with:
-          otlpEndpoint: ${{ secrets.OTLP_ENDPOINT }}
+          otlpEndpoint: ${{ secrets.OTLP_ENDPOINT }}/v1/traces
           otlpHeaders: ${{ secrets.OTLP_HEADERS }}
           otelServiceName: "clickstack-helm-chart-integration-test"
           githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/chart-test.yml
+++ b/.github/workflows/chart-test.yml
@@ -137,7 +137,7 @@ jobs:
           sleep 30
 
       - name: Verify deployment
-        timeout-minutes: 1
+        timeout-minutes: 4
         run: |
           echo "Initial pod status:"
           kubectl get pods -o wide

--- a/.github/workflows/chart-test.yml
+++ b/.github/workflows/chart-test.yml
@@ -137,6 +137,7 @@ jobs:
           sleep 30
 
       - name: Verify deployment
+        timeout-minutes: 1
         run: |
           echo "Initial pod status:"
           kubectl get pods -o wide

--- a/.github/workflows/chart-test.yml
+++ b/.github/workflows/chart-test.yml
@@ -181,3 +181,17 @@ jobs:
         run: |
           helm uninstall hyperdx-test || true
           kind delete cluster --name hyperdx-test || true
+
+  otel-cicd-action:
+    if: always()
+    name: OpenTelemetry Export Trace
+    runs-on: ubuntu-latest
+    needs: [test-helm-chart]
+    steps:
+      - name: Export workflow
+        uses: corentinmusard/otel-cicd-action@v4
+        with:
+          otlpEndpoint: ${{ secrets.OTLP_ENDPOINT }}
+          otlpHeaders: ${{ secrets.OTLP_HEADERS }}
+          otelServiceName: "clickstack-helm-chart-integration-test"
+          githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -33,13 +33,11 @@ hyperdx:
     timeoutSeconds: 5
     failureThreshold: 3
   # Add nodeSelector and tolerations for hyperdx service
-  nodeSelector:
-    {}
+  nodeSelector: {}
     # Example:
     # kubernetes.io/os: linux
     # node-role.kubernetes.io/worker: "true"
-  tolerations:
-    []
+  tolerations: []
     # Example:
     # - key: "key1"
     #   operator: "Equal"
@@ -61,16 +59,13 @@ hyperdx:
   mongoUri: mongodb://{{ include "clickstack.fullname" . }}-mongodb:{{ .Values.mongodb.port }}/hyperdx
 
   # Pod-level annotations (applied to the deployment pods)
-  annotations:
-    {}
+  annotations: {}
     # myAnnotation: "myValue"
 
   # Pod-level labels (applied to the deployment pods)
-  labels:
-    {}
+  labels: {}
     # myLabel: "myValue"
-  env:
-    []
+  env: []
     # Additional environment variables can be configured here
     # This is preserved for backward compatibility and advanced use cases
 
@@ -247,8 +242,7 @@ hyperdx:
   service:
     type: ClusterIP # Use ClusterIP for security. For external access, use ingress with proper TLS and authentication
     # Service-level annotations (applied to the Kubernetes service resource)
-    annotations:
-      {}
+    annotations: {}
       # Example service annotations:
       # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
       # cloud.google.com/load-balancer-type: "Internal"
@@ -264,13 +258,11 @@ mongodb:
   # at a cost of short mongodb downtime.
   strategy: null
   # Add nodeSelector and tolerations for mongodb service
-  nodeSelector:
-    {}
+  nodeSelector: {}
     # Example:
     # kubernetes.io/os: linux
     # node-role.kubernetes.io/worker: "true"
-  tolerations:
-    []
+  tolerations: []
     # Example:
     # - key: "key1"
     #   operator: "Equal"
@@ -297,8 +289,7 @@ clickhouse:
   port: 8123
   nativePort: 9000
   terminationGracePeriodSeconds: 90
-  resources:
-    {}
+  resources: {}
     # Example:
     # requests:
     #   memory: "512Mi"
@@ -326,13 +317,11 @@ clickhouse:
     failureThreshold: 30
   enabled: true
   # Add nodeSelector and tolerations for clickhouse service
-  nodeSelector:
-    {}
+  nodeSelector: {}
     # Example:
     # kubernetes.io/os: linux
     # node-role.kubernetes.io/worker: "true"
-  tolerations:
-    []
+  tolerations: []
     # Example:
     # - key: "key1"
     #   operator: "Equal"
@@ -343,8 +332,7 @@ clickhouse:
   service:
     type: ClusterIP # Use ClusterIP for security. For external access, use ingress with proper TLS and authentication
     # Service-level annotations (applied to the Kubernetes service resource)
-    annotations:
-      {}
+    annotations: {}
       # Example service annotations:
       # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
       # cloud.google.com/load-balancer-type: "Internal"
@@ -373,12 +361,11 @@ clickhouse:
 
 otel:
   image:
-    repository: docker.clickhouse.com/clickhouse/clickstack-otel-collector
+    repository: docker.clickhouse.xyz/clickhouse/clickstack-otel-collector
     tag:
     pullPolicy: IfNotPresent
   replicas: 1
-  resources:
-    {}
+  resources: {}
     # Example:
     # requests:
     #   memory: "127Mi"
@@ -387,17 +374,14 @@ otel:
     #   memory: "256Mi"
     #   cpu: "200m"
   # Pod-level annotations (applied to the deployment pods)
-  annotations:
-    {}
+  annotations: {}
     # myAnnotation: "myValue"
   # Add nodeSelector and tolerations for otel-collector service
-  nodeSelector:
-    {}
+  nodeSelector: {}
     # Example:
     # kubernetes.io/os: linux
     # node-role.kubernetes.io/worker: "true"
-  tolerations:
-    []
+  tolerations: []
     # Example:
     # - key: "key1"
     #   operator: "Equal"
@@ -409,8 +393,7 @@ otel:
   httpPort: 4318
   healthPort: 8888
   enabled: true
-  env:
-    []
+  env: []
     # Additional environment variables can be configured here
     # Example:
     # - name: CUSTOM_VAR
@@ -478,8 +461,7 @@ tasks:
   checkAlerts:
     schedule: "*/1 * * * *" # Runs every 1 minute
 
-    additionalArgs:
-      {}
+    additionalArgs: {}
       # Additional command line arguments can be supplied to the check-alerts
       # task by defining the param as a key/value pair. These are passed to the
       # task without validation in the helm chart.

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -33,11 +33,13 @@ hyperdx:
     timeoutSeconds: 5
     failureThreshold: 3
   # Add nodeSelector and tolerations for hyperdx service
-  nodeSelector: {}
+  nodeSelector:
+    {}
     # Example:
     # kubernetes.io/os: linux
     # node-role.kubernetes.io/worker: "true"
-  tolerations: []
+  tolerations:
+    []
     # Example:
     # - key: "key1"
     #   operator: "Equal"
@@ -59,13 +61,16 @@ hyperdx:
   mongoUri: mongodb://{{ include "clickstack.fullname" . }}-mongodb:{{ .Values.mongodb.port }}/hyperdx
 
   # Pod-level annotations (applied to the deployment pods)
-  annotations: {}
+  annotations:
+    {}
     # myAnnotation: "myValue"
 
   # Pod-level labels (applied to the deployment pods)
-  labels: {}
+  labels:
+    {}
     # myLabel: "myValue"
-  env: []
+  env:
+    []
     # Additional environment variables can be configured here
     # This is preserved for backward compatibility and advanced use cases
 
@@ -242,7 +247,8 @@ hyperdx:
   service:
     type: ClusterIP # Use ClusterIP for security. For external access, use ingress with proper TLS and authentication
     # Service-level annotations (applied to the Kubernetes service resource)
-    annotations: {}
+    annotations:
+      {}
       # Example service annotations:
       # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
       # cloud.google.com/load-balancer-type: "Internal"
@@ -258,11 +264,13 @@ mongodb:
   # at a cost of short mongodb downtime.
   strategy: null
   # Add nodeSelector and tolerations for mongodb service
-  nodeSelector: {}
+  nodeSelector:
+    {}
     # Example:
     # kubernetes.io/os: linux
     # node-role.kubernetes.io/worker: "true"
-  tolerations: []
+  tolerations:
+    []
     # Example:
     # - key: "key1"
     #   operator: "Equal"
@@ -289,7 +297,8 @@ clickhouse:
   port: 8123
   nativePort: 9000
   terminationGracePeriodSeconds: 90
-  resources: {}
+  resources:
+    {}
     # Example:
     # requests:
     #   memory: "512Mi"
@@ -317,11 +326,13 @@ clickhouse:
     failureThreshold: 30
   enabled: true
   # Add nodeSelector and tolerations for clickhouse service
-  nodeSelector: {}
+  nodeSelector:
+    {}
     # Example:
     # kubernetes.io/os: linux
     # node-role.kubernetes.io/worker: "true"
-  tolerations: []
+  tolerations:
+    []
     # Example:
     # - key: "key1"
     #   operator: "Equal"
@@ -332,7 +343,8 @@ clickhouse:
   service:
     type: ClusterIP # Use ClusterIP for security. For external access, use ingress with proper TLS and authentication
     # Service-level annotations (applied to the Kubernetes service resource)
-    annotations: {}
+    annotations:
+      {}
       # Example service annotations:
       # service.beta.kubernetes.io/aws-load-balancer-internal: "true"
       # cloud.google.com/load-balancer-type: "Internal"
@@ -361,11 +373,12 @@ clickhouse:
 
 otel:
   image:
-    repository: docker.clickhouse.xyz/clickhouse/clickstack-otel-collector
+    repository: docker.clickhouse.com/clickhouse/clickstack-otel-collector
     tag:
     pullPolicy: IfNotPresent
   replicas: 1
-  resources: {}
+  resources:
+    {}
     # Example:
     # requests:
     #   memory: "127Mi"
@@ -374,14 +387,17 @@ otel:
     #   memory: "256Mi"
     #   cpu: "200m"
   # Pod-level annotations (applied to the deployment pods)
-  annotations: {}
+  annotations:
+    {}
     # myAnnotation: "myValue"
   # Add nodeSelector and tolerations for otel-collector service
-  nodeSelector: {}
+  nodeSelector:
+    {}
     # Example:
     # kubernetes.io/os: linux
     # node-role.kubernetes.io/worker: "true"
-  tolerations: []
+  tolerations:
+    []
     # Example:
     # - key: "key1"
     #   operator: "Equal"
@@ -393,7 +409,8 @@ otel:
   httpPort: 4318
   healthPort: 8888
   enabled: true
-  env: []
+  env:
+    []
     # Additional environment variables can be configured here
     # Example:
     # - name: CUSTOM_VAR
@@ -461,7 +478,8 @@ tasks:
   checkAlerts:
     schedule: "*/1 * * * *" # Runs every 1 minute
 
-    additionalArgs: {}
+    additionalArgs:
+      {}
       # Additional command line arguments can be supplied to the check-alerts
       # task by defining the param as a key/value pair. These are passed to the
       # task without validation in the helm chart.


### PR DESCRIPTION
## Summary
- Adds an `otel-cicd-action` job to the Helm chart integration test workflow that exports CI/CD trace data via OpenTelemetry
- Uses `corentinmusard/otel-cicd-action@v4` to send workflow execution traces to the configured OTLP endpoint
- The job runs after `test-helm-chart` completes (regardless of success/failure) to ensure traces are always exported

## Configuration
- `OTLP_ENDPOINT` and `OTLP_HEADERS` are read from repository secrets
- Service name is set to `clickstack-helm-chart-integration-test`

Ref: HDX-3503