### PR TITLE
feat: Allow mongodb and waitForMongodb resources to be specified

### DIFF
--- a/charts/clickstack/templates/hyperdx-deployment.yaml
+++ b/charts/clickstack/templates/hyperdx-deployment.yaml
@@ -53,6 +53,9 @@ spec:
           image: {{ .Values.hyperdx.waitForMongodb.image }}
           imagePullPolicy: {{ .Values.hyperdx.waitForMongodb.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "clickstack.fullname" . }}-mongodb {{ .Values.mongodb.port }}; do echo waiting for mongodb; sleep 2; done;']
+          {{- if .Values.hyperdx.waitForMongodb.resources }}
+          resources: {{- toYaml .Values.hyperdx.waitForMongodb.resources | nindent 12 }}
+          {{- end }}
       {{- end }}
       containers:
         - name: app

--- a/charts/clickstack/templates/mongodb-deployment.yaml
+++ b/charts/clickstack/templates/mongodb-deployment.yaml
@@ -70,6 +70,10 @@ spec:
             timeoutSeconds: {{ .Values.mongodb.livenessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.mongodb.livenessProbe.failureThreshold }}
           {{- end }}
+          {{- if .Values.mongodb.resources }}
+          resources:
+            {{- toYaml .Values.mongodb.resources | nindent 12 }}
+          {{- end }}
           {{- if .Values.mongodb.readinessProbe.enabled }}
           readinessProbe:
             tcpSocket:

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -19,6 +19,15 @@ hyperdx:
   waitForMongodb:
     # Image used by the init container that waits for MongoDB to be reachable.
     image: "busybox@sha256:1fcf5df59121b92d61e066df1788e8df0cc35623f5d62d9679a41e163b6a0cdb"
+    resources:
+      {}
+      # Example:
+      # requests:
+      #   memory: "100Mi"
+      #   cpu: "100m"
+      # limits:
+      #   memory: "200Mi"
+      #   cpu: "500m"
     pullPolicy: IfNotPresent
   livenessProbe:
     enabled: true
@@ -276,6 +285,15 @@ mongodb:
     #   operator: "Equal"
     #   value: "value1"
     #   effect: "NoSchedule"
+  resources:
+    {}
+    # Example:
+    # requests:
+    #   memory: "512Mi"
+    #   cpu: "500m"
+    # limits:
+    #   memory: "2Gi"
+    #   cpu: "2000m"
   persistence:
     enabled: true
     dataSize: 10Gi


### PR DESCRIPTION
Add optional resource specifications for the mongodb deployment and waitForMongodb init container. Required in k8s clusters that enforce namespace quotas.