### PR TITLE
fix(ci): add helm repo definitions before chart-releaser packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,6 +43,11 @@ jobs:
           publish: yarn run release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Add Helm dependency repositories
+        run: |
+          helm repo add mongodb https://mongodb.github.io/helm-charts
+          helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
+          helm repo update
       - name: Run chart-releaser job
         if: steps.changesets.outputs.hasChangesets == 'false'
         uses: helm/chart-releaser-action@v1.7.0


### PR DESCRIPTION
## Summary

- Adds a `helm repo add` step to the release workflow for the MongoDB and OpenTelemetry HTTP-based Helm repositories
- Fixes `cr package` failure: `Error: no repository definition for https://mongodb.github.io/helm-charts`
- Both `clickstack-operators` (mongodb-kubernetes) and `clickstack` (opentelemetry-collector) charts depend on sub-charts hosted in classic HTTP Helm repos that must be registered before packaging

## Test plan

- [ ] Merge and verify the next release workflow run packages charts without the "no repository definition" error

Made with [Cursor](https://cursor.com)