### PR TITLE
feat: add additionalManifests for arbitrary Kubernetes objects

### DIFF
--- a/.changeset/additional-manifests.md
+++ b/.changeset/additional-manifests.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": minor
+---
+
+Add `additionalManifests` value for deploying arbitrary Kubernetes objects (NetworkPolicy, HPA, ServiceAccount, PodMonitor, ALB Ingress, etc.) alongside the chart. See docs/ADDITIONAL-MANIFESTS.md for usage and examples.

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -37,6 +37,11 @@ jobs:
           helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
           helm dependency build charts/clickstack
 
+      - name: Validate ALB example values render
+        run: |
+          helm template clickstack-example charts/clickstack \
+            -f examples/alb-ingress/values.yaml >/dev/null
+
       - name: Run helm-unittest
         run: |
           helm unittest charts/clickstack

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ For configuration, cloud deployment, ingress setup, and troubleshooting, see the
 - **`clickstack/clickstack-operators`** - Installs the MongoDB and ClickHouse operator controllers and CRDs. Must be installed first.
 - **`clickstack/clickstack`** - Installs HyperDX, OpenTelemetry Collector, and operator custom resources.
 
+## Additional Manifests
+
+The `clickstack` chart supports deploying arbitrary Kubernetes objects (NetworkPolicy, HPA, ServiceAccount, PodMonitor, ALB Ingress, etc.) alongside the chart's own resources via the `additionalManifests` value. See the [Additional Manifests Guide](docs/ADDITIONAL-MANIFESTS.md) for usage and examples.
+
 ## Operator Dependencies
 
 The `clickstack-operators` chart bundles:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For configuration, cloud deployment, ingress setup, and troubleshooting, see the
 
 ## Additional Manifests
 
-The `clickstack` chart supports deploying arbitrary Kubernetes objects (NetworkPolicy, HPA, ServiceAccount, PodMonitor, ALB Ingress, etc.) alongside the chart's own resources via the `additionalManifests` value. See the [Additional Manifests Guide](docs/ADDITIONAL-MANIFESTS.md) for usage and examples.
+The `clickstack` chart supports deploying arbitrary Kubernetes objects (NetworkPolicy, HPA, ServiceAccount, PodMonitor, ALB Ingress, etc.) alongside the chart's own resources via the `additionalManifests` value. See the [Additional Manifests Guide](docs/ADDITIONAL-MANIFESTS.md) for values-file constraints and examples, including [AWS ALB example values](examples/alb-ingress/values.yaml).
 
 ## Operator Dependencies
 

--- a/charts/clickstack/templates/additional-manifests.yaml
+++ b/charts/clickstack/templates/additional-manifests.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.additionalManifests }}
+---
+{{ tpl (toYaml .) $ }}
+{{- end }}

--- a/charts/clickstack/tests/additional-manifests_test.yaml
+++ b/charts/clickstack/tests/additional-manifests_test.yaml
@@ -1,0 +1,119 @@
+suite: Test Additional Manifests
+templates:
+  - additional-manifests.yaml
+tests:
+  - it: should render nothing when additionalManifests is empty
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: should render a single manifest
+    set:
+      additionalManifests:
+        - apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            name: my-extra-config
+          data:
+            key: value
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: ConfigMap
+      - equal:
+          path: metadata.name
+          value: my-extra-config
+      - equal:
+          path: data.key
+          value: value
+
+  - it: should render multiple manifests
+    set:
+      additionalManifests:
+        - apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: my-service-account
+        - apiVersion: networking.k8s.io/v1
+          kind: NetworkPolicy
+          metadata:
+            name: my-network-policy
+          spec:
+            podSelector:
+              matchLabels:
+                app: test
+    asserts:
+      - hasDocuments:
+          count: 2
+      - isKind:
+          of: ServiceAccount
+        documentIndex: 0
+      - equal:
+          path: metadata.name
+          value: my-service-account
+        documentIndex: 0
+      - isKind:
+          of: NetworkPolicy
+        documentIndex: 1
+      - equal:
+          path: metadata.name
+          value: my-network-policy
+        documentIndex: 1
+
+  - it: should evaluate tpl expressions in manifest values
+    set:
+      additionalManifests:
+        - apiVersion: v1
+          kind: ServiceAccount
+          metadata:
+            name: '{{ include "clickstack.fullname" . }}-sa'
+    asserts:
+      - hasDocuments:
+          count: 1
+      - matchRegex:
+          path: metadata.name
+          pattern: -clickstack-sa$
+
+  - it: should render an ALB Ingress with controller-specific annotations
+    set:
+      additionalManifests:
+        - apiVersion: networking.k8s.io/v1
+          kind: Ingress
+          metadata:
+            name: my-alb-ingress
+            annotations:
+              alb.ingress.kubernetes.io/scheme: internet-facing
+              alb.ingress.kubernetes.io/target-type: ip
+              alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:123456789:certificate/abc-123"
+              alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+          spec:
+            ingressClassName: alb
+            rules:
+              - host: clickstack.example.com
+                http:
+                  paths:
+                    - path: /
+                      pathType: Prefix
+                      backend:
+                        service:
+                          name: my-app
+                          port:
+                            number: 3000
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Ingress
+      - equal:
+          path: spec.ingressClassName
+          value: alb
+      - equal:
+          path: metadata.annotations["alb.ingress.kubernetes.io/scheme"]
+          value: internet-facing
+      - equal:
+          path: metadata.annotations["alb.ingress.kubernetes.io/target-type"]
+          value: ip
+      - equal:
+          path: metadata.annotations["alb.ingress.kubernetes.io/certificate-arn"]
+          value: "arn:aws:acm:us-east-1:123456789:certificate/abc-123"

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -318,6 +318,13 @@ clickhouse:
           keep_alive_timeout: 64
           max_concurrent_queries: 100
 
+# Additional Kubernetes manifests to deploy alongside the chart.
+# Each entry is a complete Kubernetes object. Values are rendered through
+# Helm's tpl function so template expressions (Release.Name, include, .Values)
+# are available inside string fields.
+# See docs/ADDITIONAL-MANIFESTS.md for full examples.
+additionalManifests: []
+
 # OpenTelemetry Collector subchart configuration (alias: otel-collector)
 # See https://github.com/open-telemetry/opentelemetry-helm-charts for all options
 # Set otel-collector.enabled to false to disable the OTEL collector entirely.

--- a/docs/ADDITIONAL-MANIFESTS.md
+++ b/docs/ADDITIONAL-MANIFESTS.md
@@ -1,0 +1,291 @@
+# Additional Manifests
+
+The `additionalManifests` value lets you deploy arbitrary Kubernetes objects alongside the ClickStack chart. Use it to add resources that the chart does not template natively -- NetworkPolicy, HorizontalPodAutoscaler, ServiceAccount, PodMonitor, custom Ingress controllers, or any other Kubernetes API object.
+
+## How it works
+
+Each entry in `additionalManifests` is a complete Kubernetes resource definition. The chart iterates over the list, converts each entry to YAML, and passes it through Helm's `tpl` function. This means you can use any Helm template expression inside string values:
+
+- `.Release.Name`, `.Release.Namespace`
+- `include "clickstack.fullname" .` and other chart helpers
+- `.Values.*` references
+
+```yaml
+# values.yaml
+additionalManifests:
+  - apiVersion: v1
+    kind: ConfigMap
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}-custom'
+    data:
+      release: '{{ .Release.Name }}'
+```
+
+> **Important:** Template expressions inside values must be quoted as YAML strings
+> (wrap them in single quotes). Unquoted `{{` is invalid YAML.
+
+## Available chart helpers
+
+These helpers are defined in `templates/_helpers.tpl` and can be used inside `additionalManifests` entries:
+
+| Helper | Description | Example output |
+|--------|-------------|----------------|
+| `clickstack.name` | Chart name (truncated to 63 chars) | `clickstack` |
+| `clickstack.fullname` | Release-qualified name | `my-release-clickstack` |
+| `clickstack.chart` | Chart name + version | `clickstack-2.0.0` |
+| `clickstack.labels` | Standard Helm labels block | *(multi-line)* |
+| `clickstack.selectorLabels` | `app.kubernetes.io/name` + `instance` | *(multi-line)* |
+| `clickstack.mongodb.fullname` | MongoDB CR name | `my-release-clickstack-mongodb` |
+| `clickstack.clickhouse.fullname` | ClickHouse CR name | `my-release-clickstack-clickhouse` |
+| `clickstack.otel.fullname` | OTEL Collector name | `my-release-otel-collector` |
+
+## Examples
+
+### ServiceAccount
+
+```yaml
+additionalManifests:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}'
+      namespace: '{{ .Release.Namespace }}'
+      labels:
+        {{- include "clickstack.labels" . | nindent 8 }}
+      annotations:
+        eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/my-role"
+```
+
+### NetworkPolicy
+
+Restrict ingress traffic to the HyperDX pods:
+
+```yaml
+additionalManifests:
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}-allow-ingress'
+    spec:
+      podSelector:
+        matchLabels:
+          {{- include "clickstack.selectorLabels" . | nindent 10 }}
+      policyTypes:
+        - Ingress
+      ingress:
+        - from:
+            - namespaceSelector:
+                matchLabels:
+                  kubernetes.io/metadata.name: ingress-nginx
+          ports:
+            - protocol: TCP
+              port: {{ .Values.hyperdx.ports.app }}
+            - protocol: TCP
+              port: {{ .Values.hyperdx.ports.api }}
+```
+
+### HorizontalPodAutoscaler
+
+```yaml
+additionalManifests:
+  - apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}-hpa'
+    spec:
+      scaleTargetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: '{{ include "clickstack.fullname" . }}-app'
+      minReplicas: 2
+      maxReplicas: 10
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 75
+```
+
+### PodMonitor (Prometheus Operator)
+
+```yaml
+additionalManifests:
+  - apiVersion: monitoring.coreos.com/v1
+    kind: PodMonitor
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}'
+      labels:
+        {{- include "clickstack.labels" . | nindent 8 }}
+    spec:
+      selector:
+        matchLabels:
+          {{- include "clickstack.selectorLabels" . | nindent 10 }}
+      podMetricsEndpoints:
+        - port: metrics
+          interval: 30s
+```
+
+### AWS ALB Ingress
+
+When using the [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/), disable the chart's built-in nginx-centric Ingress and define a fully custom one:
+
+```yaml
+hyperdx:
+  ingress:
+    enabled: false   # disable the built-in nginx Ingress
+
+additionalManifests:
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}-alb'
+      labels:
+        {{- include "clickstack.labels" . | nindent 8 }}
+      annotations:
+        alb.ingress.kubernetes.io/scheme: internet-facing
+        alb.ingress.kubernetes.io/target-type: ip
+        alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:123456789:certificate/abc-123"
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+        alb.ingress.kubernetes.io/ssl-redirect: "443"
+        alb.ingress.kubernetes.io/group.name: clickstack
+        alb.ingress.kubernetes.io/healthcheck-path: /api/health
+        alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
+        alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+        alb.ingress.kubernetes.io/healthy-threshold-count: "2"
+        alb.ingress.kubernetes.io/unhealthy-threshold-count: "3"
+    spec:
+      ingressClassName: alb
+      rules:
+        - host: clickstack.example.com
+          http:
+            paths:
+              - path: /
+                pathType: Prefix
+                backend:
+                  service:
+                    name: '{{ include "clickstack.fullname" . }}-app'
+                    port:
+                      number: {{ .Values.hyperdx.ports.app }}
+```
+
+If you also need the OTEL collector exposed through the ALB, add a second entry:
+
+```yaml
+additionalManifests:
+  # ... app Ingress above ...
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}-alb-otel'
+      annotations:
+        alb.ingress.kubernetes.io/scheme: internal
+        alb.ingress.kubernetes.io/target-type: ip
+        alb.ingress.kubernetes.io/group.name: clickstack-otel
+        alb.ingress.kubernetes.io/healthcheck-path: /
+        alb.ingress.kubernetes.io/healthcheck-port: "13133"
+    spec:
+      ingressClassName: alb
+      rules:
+        - host: otel.internal.example.com
+          http:
+            paths:
+              - path: /
+                pathType: Prefix
+                backend:
+                  service:
+                    name: '{{ include "clickstack.otel.fullname" . }}'
+                    port:
+                      number: 4318
+```
+
+For a complete, ready-to-use ALB example, see [`examples/alb-ingress/`](../examples/alb-ingress/).
+
+### TargetGroupBinding
+
+For ALB scenarios that require explicit TargetGroupBinding resources (e.g. pre-provisioned target groups):
+
+```yaml
+additionalManifests:
+  - apiVersion: elbv2.k8s.aws/v1beta1
+    kind: TargetGroupBinding
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}-tgb'
+    spec:
+      serviceRef:
+        name: '{{ include "clickstack.fullname" . }}-app'
+        port: {{ .Values.hyperdx.ports.app }}
+      targetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:123456789:targetgroup/my-tg/abc123"
+      targetType: ip
+```
+
+## Tips
+
+### Quoting template expressions
+
+YAML requires `{{` to be inside a quoted string. Always use single quotes around values that contain template expressions:
+
+```yaml
+# Correct
+name: '{{ include "clickstack.fullname" . }}'
+
+# Incorrect -- YAML parse error
+name: {{ include "clickstack.fullname" . }}
+```
+
+### Helm hooks
+
+Each `additionalManifests` entry is rendered as a separate YAML document. You can add Helm hook annotations to control install/upgrade ordering:
+
+```yaml
+additionalManifests:
+  - apiVersion: batch/v1
+    kind: Job
+    metadata:
+      name: post-install-job
+      annotations:
+        helm.sh/hook: post-install
+        helm.sh/hook-delete-policy: hook-succeeded
+    spec:
+      template:
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: migrate
+              image: my-migration-image:latest
+              command: ["./migrate.sh"]
+```
+
+### CRD ordering
+
+If your additional manifests include custom resource instances (e.g. `PodMonitor`), the CRDs must already exist in the cluster. Install CRDs before the chart release, either via the operator chart (`clickstack-operators`) or a separate step. Helm installs CRDs from `crds/` before templates, but `additionalManifests` entries are normal templates and cannot define CRDs.
+
+### Combining multiple resources
+
+You can define as many entries as needed. They are rendered in list order:
+
+```yaml
+additionalManifests:
+  - apiVersion: v1
+    kind: ServiceAccount
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}'
+  - apiVersion: networking.k8s.io/v1
+    kind: NetworkPolicy
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}-netpol'
+    spec:
+      podSelector: {}
+  - apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}-hpa'
+    spec:
+      scaleTargetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: '{{ include "clickstack.fullname" . }}-app'
+      minReplicas: 2
+      maxReplicas: 10
+```

--- a/docs/ADDITIONAL-MANIFESTS.md
+++ b/docs/ADDITIONAL-MANIFESTS.md
@@ -1,17 +1,22 @@
 # Additional Manifests
 
-The `additionalManifests` value lets you deploy arbitrary Kubernetes objects alongside the ClickStack chart. Use it to add resources that the chart does not template natively -- NetworkPolicy, HorizontalPodAutoscaler, ServiceAccount, PodMonitor, custom Ingress controllers, or any other Kubernetes API object.
+The `additionalManifests` value lets you deploy arbitrary Kubernetes objects alongside the ClickStack chart. Use it for resources that the chart does not template natively, such as `NetworkPolicy`, `HorizontalPodAutoscaler`, `ServiceAccount`, `PodMonitor`, custom `Ingress` objects, or any other Kubernetes API object.
 
 ## How it works
 
-Each entry in `additionalManifests` is a complete Kubernetes resource definition. The chart iterates over the list, converts each entry to YAML, and passes it through Helm's `tpl` function. This means you can use any Helm template expression inside string values:
+Each entry in `additionalManifests` is a complete Kubernetes resource definition. The chart:
+
+1. Iterates over each entry in the list
+2. Converts the entry to YAML (`toYaml`)
+3. Evaluates template expressions in that YAML using Helm `tpl`
+
+Template expressions can reference:
 
 - `.Release.Name`, `.Release.Namespace`
 - `include "clickstack.fullname" .` and other chart helpers
-- `.Values.*` references
+- `.Values.*`
 
 ```yaml
-# values.yaml
 additionalManifests:
   - apiVersion: v1
     kind: ConfigMap
@@ -21,25 +26,43 @@ additionalManifests:
       release: '{{ .Release.Name }}'
 ```
 
-> **Important:** Template expressions inside values must be quoted as YAML strings
-> (wrap them in single quotes). Unquoted `{{` is invalid YAML.
+## Values file constraints
+
+`additionalManifests` is configured in a values file, and values files are parsed as YAML before `tpl` runs.
+
+- Any `{{ ... }}` in a values file must be inside a quoted string.
+- Structural template blocks are not valid values YAML (for example, `{{- include ... | nindent ... }}` by itself).
+- For non-string fields (for example, numeric ports), use literal values or named ports.
+- If you need structural templating, use a wrapper chart template instead of a raw values file.
+
+```yaml
+# Valid in values.yaml
+name: '{{ include "clickstack.fullname" . }}-app'
+
+# Invalid in values.yaml (unquoted template expression)
+name: {{ include "clickstack.fullname" . }}-app
+
+# Invalid in values.yaml (structural template block)
+labels:
+  {{- include "clickstack.labels" . | nindent 2 }}
+```
 
 ## Available chart helpers
 
-These helpers are defined in `templates/_helpers.tpl` and can be used inside `additionalManifests` entries:
+These helpers are defined in `templates/_helpers.tpl`:
 
-| Helper | Description | Example output |
-|--------|-------------|----------------|
-| `clickstack.name` | Chart name (truncated to 63 chars) | `clickstack` |
-| `clickstack.fullname` | Release-qualified name | `my-release-clickstack` |
-| `clickstack.chart` | Chart name + version | `clickstack-2.0.0` |
-| `clickstack.labels` | Standard Helm labels block | *(multi-line)* |
-| `clickstack.selectorLabels` | `app.kubernetes.io/name` + `instance` | *(multi-line)* |
-| `clickstack.mongodb.fullname` | MongoDB CR name | `my-release-clickstack-mongodb` |
-| `clickstack.clickhouse.fullname` | ClickHouse CR name | `my-release-clickstack-clickhouse` |
-| `clickstack.otel.fullname` | OTEL Collector name | `my-release-otel-collector` |
+| Helper | Description | Values-file usage |
+|--------|-------------|-------------------|
+| `clickstack.name` | Chart name (truncated to 63 chars) | Safe in quoted scalars |
+| `clickstack.fullname` | Release-qualified name | Safe in quoted scalars |
+| `clickstack.chart` | Chart name + version | Safe in quoted scalars |
+| `clickstack.selectorLabels` | Selector labels block | Wrapper chart templates only |
+| `clickstack.labels` | Standard labels block | Wrapper chart templates only |
+| `clickstack.mongodb.fullname` | MongoDB CR name | Safe in quoted scalars |
+| `clickstack.clickhouse.fullname` | ClickHouse CR name | Safe in quoted scalars |
+| `clickstack.otel.fullname` | OTEL Collector name | Safe in quoted scalars |
 
-## Examples
+## Values-file examples
 
 ### ServiceAccount
 
@@ -51,14 +74,15 @@ additionalManifests:
       name: '{{ include "clickstack.fullname" . }}'
       namespace: '{{ .Release.Namespace }}'
       labels:
-        {{- include "clickstack.labels" . | nindent 8 }}
+        app.kubernetes.io/name: '{{ include "clickstack.name" . }}'
+        app.kubernetes.io/instance: '{{ .Release.Name }}'
       annotations:
         eks.amazonaws.com/role-arn: "arn:aws:iam::123456789:role/my-role"
 ```
 
 ### NetworkPolicy
 
-Restrict ingress traffic to the HyperDX pods:
+Restrict ingress traffic to HyperDX pods:
 
 ```yaml
 additionalManifests:
@@ -69,7 +93,8 @@ additionalManifests:
     spec:
       podSelector:
         matchLabels:
-          {{- include "clickstack.selectorLabels" . | nindent 10 }}
+          app.kubernetes.io/name: '{{ include "clickstack.name" . }}'
+          app.kubernetes.io/instance: '{{ .Release.Name }}'
       policyTypes:
         - Ingress
       ingress:
@@ -79,9 +104,9 @@ additionalManifests:
                   kubernetes.io/metadata.name: ingress-nginx
           ports:
             - protocol: TCP
-              port: {{ .Values.hyperdx.ports.app }}
+              port: 3000
             - protocol: TCP
-              port: {{ .Values.hyperdx.ports.api }}
+              port: 8000
 ```
 
 ### HorizontalPodAutoscaler
@@ -117,32 +142,31 @@ additionalManifests:
     metadata:
       name: '{{ include "clickstack.fullname" . }}'
       labels:
-        {{- include "clickstack.labels" . | nindent 8 }}
+        release: prometheus
     spec:
       selector:
         matchLabels:
-          {{- include "clickstack.selectorLabels" . | nindent 10 }}
+          app.kubernetes.io/name: '{{ include "clickstack.name" . }}'
+          app.kubernetes.io/instance: '{{ .Release.Name }}'
       podMetricsEndpoints:
-        - port: metrics
+        - port: app
           interval: 30s
 ```
 
 ### AWS ALB Ingress
 
-When using the [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/), disable the chart's built-in nginx-centric Ingress and define a fully custom one:
+When using the [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/), disable the chart's built-in nginx Ingress and define a custom ALB Ingress:
 
 ```yaml
 hyperdx:
   ingress:
-    enabled: false   # disable the built-in nginx Ingress
+    enabled: false
 
 additionalManifests:
   - apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       name: '{{ include "clickstack.fullname" . }}-alb'
-      labels:
-        {{- include "clickstack.labels" . | nindent 8 }}
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip
@@ -151,10 +175,6 @@ additionalManifests:
         alb.ingress.kubernetes.io/ssl-redirect: "443"
         alb.ingress.kubernetes.io/group.name: clickstack
         alb.ingress.kubernetes.io/healthcheck-path: /api/health
-        alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
-        alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
-        alb.ingress.kubernetes.io/healthy-threshold-count: "2"
-        alb.ingress.kubernetes.io/unhealthy-threshold-count: "3"
     spec:
       ingressClassName: alb
       rules:
@@ -167,44 +187,14 @@ additionalManifests:
                   service:
                     name: '{{ include "clickstack.fullname" . }}-app'
                     port:
-                      number: {{ .Values.hyperdx.ports.app }}
+                      name: app
 ```
 
-If you also need the OTEL collector exposed through the ALB, add a second entry:
-
-```yaml
-additionalManifests:
-  # ... app Ingress above ...
-  - apiVersion: networking.k8s.io/v1
-    kind: Ingress
-    metadata:
-      name: '{{ include "clickstack.fullname" . }}-alb-otel'
-      annotations:
-        alb.ingress.kubernetes.io/scheme: internal
-        alb.ingress.kubernetes.io/target-type: ip
-        alb.ingress.kubernetes.io/group.name: clickstack-otel
-        alb.ingress.kubernetes.io/healthcheck-path: /
-        alb.ingress.kubernetes.io/healthcheck-port: "13133"
-    spec:
-      ingressClassName: alb
-      rules:
-        - host: otel.internal.example.com
-          http:
-            paths:
-              - path: /
-                pathType: Prefix
-                backend:
-                  service:
-                    name: '{{ include "clickstack.otel.fullname" . }}'
-                    port:
-                      number: 4318
-```
-
-For a complete, ready-to-use ALB example, see [`examples/alb-ingress/`](../examples/alb-ingress/).
+For a complete ALB setup example, see [`examples/alb-ingress/`](../examples/alb-ingress/).
 
 ### TargetGroupBinding
 
-For ALB scenarios that require explicit TargetGroupBinding resources (e.g. pre-provisioned target groups):
+For ALB scenarios that require explicit `TargetGroupBinding` resources:
 
 ```yaml
 additionalManifests:
@@ -215,24 +205,29 @@ additionalManifests:
     spec:
       serviceRef:
         name: '{{ include "clickstack.fullname" . }}-app'
-        port: {{ .Values.hyperdx.ports.app }}
+        port: app
       targetGroupARN: "arn:aws:elasticloadbalancing:us-east-1:123456789:targetgroup/my-tg/abc123"
       targetType: ip
 ```
 
-## Tips
+## Advanced: wrapper chart templates
 
-### Quoting template expressions
+If you need structural helpers like `include "clickstack.labels" . | nindent 4`, render them from a wrapper chart template (`templates/*.yaml`) instead of putting those blocks directly in values files.
 
-YAML requires `{{` to be inside a quoted string. Always use single quotes around values that contain template expressions:
+Example wrapper chart template snippet:
 
 ```yaml
-# Correct
-name: '{{ include "clickstack.fullname" . }}'
-
-# Incorrect -- YAML parse error
-name: {{ include "clickstack.fullname" . }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "clickstack.fullname" . }}-extra
+  labels:
+    {{- include "clickstack.labels" . | nindent 4 }}
+data:
+  appPort: "{{ .Values.hyperdx.ports.app }}"
 ```
+
+## Tips
 
 ### Helm hooks
 
@@ -259,33 +254,8 @@ additionalManifests:
 
 ### CRD ordering
 
-If your additional manifests include custom resource instances (e.g. `PodMonitor`), the CRDs must already exist in the cluster. Install CRDs before the chart release, either via the operator chart (`clickstack-operators`) or a separate step. Helm installs CRDs from `crds/` before templates, but `additionalManifests` entries are normal templates and cannot define CRDs.
+If your additional manifests include custom resources (for example, `PodMonitor`), the CRDs must already exist in the cluster before install/upgrade.
 
 ### Combining multiple resources
 
-You can define as many entries as needed. They are rendered in list order:
-
-```yaml
-additionalManifests:
-  - apiVersion: v1
-    kind: ServiceAccount
-    metadata:
-      name: '{{ include "clickstack.fullname" . }}'
-  - apiVersion: networking.k8s.io/v1
-    kind: NetworkPolicy
-    metadata:
-      name: '{{ include "clickstack.fullname" . }}-netpol'
-    spec:
-      podSelector: {}
-  - apiVersion: autoscaling/v2
-    kind: HorizontalPodAutoscaler
-    metadata:
-      name: '{{ include "clickstack.fullname" . }}-hpa'
-    spec:
-      scaleTargetRef:
-        apiVersion: apps/v1
-        kind: Deployment
-        name: '{{ include "clickstack.fullname" . }}-app'
-      minReplicas: 2
-      maxReplicas: 10
-```
+`additionalManifests` is a list. Entries are rendered in list order, and each entry becomes its own YAML document.

--- a/examples/alb-ingress/README.md
+++ b/examples/alb-ingress/README.md
@@ -1,0 +1,48 @@
+# ClickStack with AWS ALB Ingress
+
+This example shows how to deploy ClickStack using an [AWS Application Load Balancer](https://kubernetes-sigs.github.io/aws-load-balancer-controller/) instead of the chart's built-in nginx Ingress.
+
+## What's included
+
+The `values.yaml` in this directory:
+
+- Disables the built-in nginx Ingress (`hyperdx.ingress.enabled: false`)
+- Creates a public-facing ALB Ingress for the HyperDX app with HTTPS, SSL redirect, health checks, and session stickiness
+- Creates an internal ALB Ingress for the OTEL collector endpoint
+- Adds a HorizontalPodAutoscaler for the HyperDX deployment
+
+All of these are defined via `additionalManifests`, which renders arbitrary Kubernetes objects alongside the chart's own resources.
+
+## Prerequisites
+
+1. **AWS Load Balancer Controller** installed in the cluster. See the [installation guide](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/deploy/installation/).
+2. **ACM certificate** provisioned for your domain. Replace the `certificate-arn` annotation value with your ARN.
+3. **Subnets** tagged for ALB auto-discovery, or specify them explicitly via the `alb.ingress.kubernetes.io/subnets` annotation.
+
+## Usage
+
+```bash
+# Install operators first (if not already installed)
+helm install clickstack-operators clickstack/clickstack-operators
+
+# Install ClickStack with ALB values
+helm install my-clickstack clickstack/clickstack \
+  -f examples/alb-ingress/values.yaml
+```
+
+## Customization
+
+Edit `values.yaml` to match your environment:
+
+| Setting | Where to change | Description |
+|---------|-----------------|-------------|
+| Domain | `rules[].host` | Replace `clickstack.example.com` and `otel.internal.example.com` with your domains |
+| Certificate | `certificate-arn` annotation | Replace with your ACM certificate ARN |
+| ALB scheme | `scheme` annotation | `internet-facing` for public, `internal` for private |
+| Subnets | Add `subnets` annotation | Explicit subnet IDs if auto-discovery is not configured |
+| HPA thresholds | `minReplicas`, `maxReplicas`, `averageUtilization` | Tune autoscaling to your workload |
+
+## Further reading
+
+- [Additional Manifests Guide](../../docs/ADDITIONAL-MANIFESTS.md) for the full reference on `additionalManifests`
+- [AWS Load Balancer Controller annotations](https://kubernetes-sigs.github.io/aws-load-balancer-controller/latest/guide/ingress/annotations/) for all available ALB annotations

--- a/examples/alb-ingress/README.md
+++ b/examples/alb-ingress/README.md
@@ -12,6 +12,7 @@ The `values.yaml` in this directory:
 - Adds a HorizontalPodAutoscaler for the HyperDX deployment
 
 All of these are defined via `additionalManifests`, which renders arbitrary Kubernetes objects alongside the chart's own resources.
+This file is intentionally plain values YAML so it works directly with `-f` (without wrapper-chart template blocks like `{{- include ... | nindent ... }}`).
 
 ## Prerequisites
 
@@ -28,6 +29,9 @@ helm install clickstack-operators clickstack/clickstack-operators
 # Install ClickStack with ALB values
 helm install my-clickstack clickstack/clickstack \
   -f examples/alb-ingress/values.yaml
+
+# Or, from this directory:
+# helm install my-clickstack clickstack/clickstack -f values.yaml
 ```
 
 ## Customization

--- a/examples/alb-ingress/values.yaml
+++ b/examples/alb-ingress/values.yaml
@@ -12,6 +12,8 @@
 #
 # Usage:
 #   helm install my-clickstack clickstack/clickstack -f values.yaml
+#   # From repo root:
+#   # helm install my-clickstack clickstack/clickstack -f examples/alb-ingress/values.yaml
 #
 # Customize the values below for your environment:
 #   - Replace certificate-arn with your ACM certificate ARN
@@ -38,8 +40,6 @@ additionalManifests:
     kind: Ingress
     metadata:
       name: '{{ include "clickstack.fullname" . }}-alb'
-      labels:
-        {{- include "clickstack.labels" . | nindent 8 }}
       annotations:
         alb.ingress.kubernetes.io/scheme: internet-facing
         alb.ingress.kubernetes.io/target-type: ip
@@ -65,15 +65,13 @@ additionalManifests:
                   service:
                     name: '{{ include "clickstack.fullname" . }}-app'
                     port:
-                      number: {{ .Values.hyperdx.ports.app }}
+                      name: app
 
   # -- ALB Ingress for the OTEL collector (internal) --
   - apiVersion: networking.k8s.io/v1
     kind: Ingress
     metadata:
       name: '{{ include "clickstack.fullname" . }}-alb-otel'
-      labels:
-        {{- include "clickstack.labels" . | nindent 8 }}
       annotations:
         alb.ingress.kubernetes.io/scheme: internal
         alb.ingress.kubernetes.io/target-type: ip
@@ -99,8 +97,6 @@ additionalManifests:
     kind: HorizontalPodAutoscaler
     metadata:
       name: '{{ include "clickstack.fullname" . }}-hpa'
-      labels:
-        {{- include "clickstack.labels" . | nindent 8 }}
     spec:
       scaleTargetRef:
         apiVersion: apps/v1

--- a/examples/alb-ingress/values.yaml
+++ b/examples/alb-ingress/values.yaml
@@ -1,0 +1,123 @@
+# ClickStack with AWS ALB Ingress
+#
+# This example deploys ClickStack with an AWS Application Load Balancer
+# instead of the chart's built-in nginx Ingress. It uses additionalManifests
+# to define a fully custom Ingress resource with ALB-specific annotations.
+#
+# Prerequisites:
+#   - AWS Load Balancer Controller installed in the cluster
+#     https://kubernetes-sigs.github.io/aws-load-balancer-controller/
+#   - ACM certificate provisioned for your domain
+#   - Subnets tagged for ALB auto-discovery (or specify them explicitly)
+#
+# Usage:
+#   helm install my-clickstack clickstack/clickstack -f values.yaml
+#
+# Customize the values below for your environment:
+#   - Replace certificate-arn with your ACM certificate ARN
+#   - Replace clickstack.example.com with your domain
+#   - Adjust ALB annotations as needed (scheme, target-type, etc.)
+
+hyperdx:
+  ingress:
+    enabled: false  # disable the built-in nginx Ingress
+
+  deployment:
+    replicas: 2
+    resources:
+      requests:
+        cpu: 500m
+        memory: 512Mi
+      limits:
+        cpu: "2"
+        memory: 2Gi
+
+additionalManifests:
+  # -- ALB Ingress for the HyperDX app (public-facing) --
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}-alb'
+      labels:
+        {{- include "clickstack.labels" . | nindent 8 }}
+      annotations:
+        alb.ingress.kubernetes.io/scheme: internet-facing
+        alb.ingress.kubernetes.io/target-type: ip
+        alb.ingress.kubernetes.io/certificate-arn: "arn:aws:acm:us-east-1:123456789:certificate/your-cert-id"
+        alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
+        alb.ingress.kubernetes.io/ssl-redirect: "443"
+        alb.ingress.kubernetes.io/group.name: clickstack
+        alb.ingress.kubernetes.io/healthcheck-path: /api/health
+        alb.ingress.kubernetes.io/healthcheck-interval-seconds: "15"
+        alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
+        alb.ingress.kubernetes.io/healthy-threshold-count: "2"
+        alb.ingress.kubernetes.io/unhealthy-threshold-count: "3"
+        alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds=3600
+    spec:
+      ingressClassName: alb
+      rules:
+        - host: clickstack.example.com
+          http:
+            paths:
+              - path: /
+                pathType: Prefix
+                backend:
+                  service:
+                    name: '{{ include "clickstack.fullname" . }}-app'
+                    port:
+                      number: {{ .Values.hyperdx.ports.app }}
+
+  # -- ALB Ingress for the OTEL collector (internal) --
+  - apiVersion: networking.k8s.io/v1
+    kind: Ingress
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}-alb-otel'
+      labels:
+        {{- include "clickstack.labels" . | nindent 8 }}
+      annotations:
+        alb.ingress.kubernetes.io/scheme: internal
+        alb.ingress.kubernetes.io/target-type: ip
+        alb.ingress.kubernetes.io/group.name: clickstack-otel
+        alb.ingress.kubernetes.io/healthcheck-path: /
+        alb.ingress.kubernetes.io/healthcheck-port: "13133"
+    spec:
+      ingressClassName: alb
+      rules:
+        - host: otel.internal.example.com
+          http:
+            paths:
+              - path: /
+                pathType: Prefix
+                backend:
+                  service:
+                    name: '{{ include "clickstack.otel.fullname" . }}'
+                    port:
+                      number: 4318
+
+  # -- HorizontalPodAutoscaler for the HyperDX app --
+  - apiVersion: autoscaling/v2
+    kind: HorizontalPodAutoscaler
+    metadata:
+      name: '{{ include "clickstack.fullname" . }}-hpa'
+      labels:
+        {{- include "clickstack.labels" . | nindent 8 }}
+    spec:
+      scaleTargetRef:
+        apiVersion: apps/v1
+        kind: Deployment
+        name: '{{ include "clickstack.fullname" . }}-app'
+      minReplicas: 2
+      maxReplicas: 10
+      metrics:
+        - type: Resource
+          resource:
+            name: cpu
+            target:
+              type: Utilization
+              averageUtilization: 75
+        - type: Resource
+          resource:
+            name: memory
+            target:
+              type: Utilization
+              averageUtilization: 80


### PR DESCRIPTION
## Summary

- Add `additionalManifests` top-level value that accepts a list of arbitrary Kubernetes objects to deploy alongside the chart. Each entry is rendered through Helm's `tpl` function, giving access to chart helpers (e.g. `clickstack.fullname`, `clickstack.labels`) and `.Values`/`.Release` context.
- Add helm-unittest test suite with 5 cases covering empty list, single manifest, multiple manifests, tpl expression evaluation, and ALB Ingress with controller-specific annotations.
- Add `docs/ADDITIONAL-MANIFESTS.md` with full usage documentation including examples for ServiceAccount, NetworkPolicy, HPA, PodMonitor, AWS ALB Ingress, and TargetGroupBinding.
- Add `examples/alb-ingress/` with a ready-to-use values file for deploying ClickStack behind an AWS ALB.

## Test plan

- [x] `helm unittest charts/clickstack` -- 25 suites, 151 tests passing
- [x] `helm lint charts/clickstack` -- 0 failures
- [x] `helm template` renders `additionalManifests` entries correctly alongside chart resources
- [x] Verify CI pipeline passes (helm-unittest + lint)


Made with [Cursor](https://cursor.com)