### PR TITLE
fix: combine ClickHouse app user grants into single query (HDX-3832)

### DIFF
--- a/.changeset/better-otters-train.md
+++ b/.changeset/better-otters-train.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+fix: combine ClickHouse app user grants into single query

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -305,9 +305,7 @@ clickhouse:
               password: '{{ .Values.hyperdx.secrets.CLICKHOUSE_APP_PASSWORD }}'
               profile: default
               grants:
-                - query: "GRANT SHOW ON *.*"
-                - query: "GRANT SELECT ON system.*"
-                - query: "GRANT SELECT ON default.*"
+                - query: "GRANT SHOW ON *.*, SELECT ON system.*, SELECT ON default.*"
             otelcollector:
               password: '{{ .Values.hyperdx.secrets.CLICKHOUSE_PASSWORD }}'
               profile: default


### PR DESCRIPTION
## Summary
- The ClickHouse operator only applies the first `grants` entry when multiple are listed separately
- The `app` user was missing `SELECT ON system.*` and `SELECT ON default.*` permissions — only `GRANT SHOW ON *.*` was applied
- Combined all grants into a single query, matching the pattern that works for the `otelcollector` user

## Test plan
- [x] `helm unittest charts/clickstack` — all 146 tests pass
- [x] Deploy and verify with `SHOW GRANTS FOR app` in ClickHouse — should show all 3 permissions

Linear: HDX-3832