### PR TITLE
fix: make -app suffix conditional on fullnameOverride (HDX-3850)

### DIFF
--- a/.changeset/conditional-app-suffix.md
+++ b/.changeset/conditional-app-suffix.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+Make the `-app` suffix on HyperDX Deployment and Service names conditional on `fullnameOverride`. When `fullnameOverride` is set, the suffix is omitted so users get full control over resource naming. The default behavior (no override) is unchanged.

--- a/charts/clickstack/templates/NOTES.txt
+++ b/charts/clickstack/templates/NOTES.txt
@@ -28,7 +28,7 @@ Application Access:
        --set hyperdx.ingress.tls.enabled=true
   
   2. Port Forward (Development/Testing):
-     kubectl port-forward svc/{{ include "clickstack.fullname" . }}-app {{ .Values.hyperdx.ports.app }}:{{ .Values.hyperdx.ports.app }}
+     kubectl port-forward svc/{{ include "clickstack.hyperdx.fullname" . }} {{ .Values.hyperdx.ports.app }}:{{ .Values.hyperdx.ports.app }}
      Then access: http://localhost:{{ .Values.hyperdx.ports.app }}
   
   Note: This application handles sensitive telemetry data and should not be exposed

--- a/charts/clickstack/templates/_helpers.tpl
+++ b/charts/clickstack/templates/_helpers.tpl
@@ -22,6 +22,19 @@ Create a default fully qualified app name.
 {{- end }}
 
 {{/*
+HyperDX app resource name. When fullnameOverride is set the user expects full
+control over naming, so the -app suffix is omitted. Without the override the
+suffix is kept for backward compatibility.
+*/}}
+{{- define "clickstack.hyperdx.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-app" (include "clickstack.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "clickstack.chart" -}}

--- a/charts/clickstack/templates/hyperdx/deployment.yaml
+++ b/charts/clickstack/templates/hyperdx/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "clickstack.fullname" . }}-app
+  name: {{ include "clickstack.hyperdx.fullname" . }}
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
     app: {{ include "clickstack.fullname" . }}

--- a/charts/clickstack/templates/hyperdx/ingress.yaml
+++ b/charts/clickstack/templates/hyperdx/ingress.yaml
@@ -2,7 +2,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: {{ include "clickstack.fullname" . }}-app-ingress
+  name: {{ include "clickstack.hyperdx.fullname" . }}-ingress
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
   annotations:
@@ -37,7 +37,7 @@ spec:
             pathType: {{ .Values.hyperdx.ingress.pathType | default "ImplementationSpecific" }}
             backend:
               service:
-                name: {{ include "clickstack.fullname" . }}-app
+                name: {{ include "clickstack.hyperdx.fullname" . }}
                 port:
                   number: {{ .Values.hyperdx.ports.app }}
 {{- range .Values.hyperdx.ingress.additionalIngresses}}

--- a/charts/clickstack/templates/hyperdx/service.yaml
+++ b/charts/clickstack/templates/hyperdx/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "clickstack.fullname" . }}-app
+  name: {{ include "clickstack.hyperdx.fullname" . }}
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
   {{- if .Values.hyperdx.service.annotations }}

--- a/charts/clickstack/tests/helpers_test.yaml
+++ b/charts/clickstack/tests/helpers_test.yaml
@@ -22,8 +22,16 @@ tests:
     asserts:
       - equal:
           path: metadata.name
-          value: direct-override-app
-          
+          value: direct-override
+
+  - it: should not append -app suffix when fullnameOverride is set
+    set:
+      fullnameOverride: hyperdx-api
+    asserts:
+      - equal:
+          path: metadata.name
+          value: hyperdx-api
+
   - it: should render common labels correctly
     asserts:
       - matchRegex:

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -38,7 +38,7 @@ hyperdx:
     CLICKHOUSE_ENDPOINT: 'tcp://{{ include "clickstack.clickhouse.svc" . }}:{{ .Values.clickhouse.nativePort }}?dial_timeout=10s'
     CLICKHOUSE_SERVER_ENDPOINT: '{{ include "clickstack.clickhouse.svc" . }}:{{ .Values.clickhouse.nativePort }}'
     CLICKHOUSE_PROMETHEUS_METRICS_ENDPOINT: '{{ include "clickstack.clickhouse.svc" . }}:{{ .Values.clickhouse.prometheus.port }}'
-    OPAMP_SERVER_URL: 'http://{{ include "clickstack.fullname" . }}-app:{{ .Values.hyperdx.ports.opamp }}'
+    OPAMP_SERVER_URL: 'http://{{ include "clickstack.hyperdx.fullname" . }}:{{ .Values.hyperdx.ports.opamp }}'
 
   # ── K8s Secret (clickstack-secret) ───────────────────────
   # Shared sensitive environment variables. Used by HyperDX and OTEL collector via envFrom.

--- a/examples/alb-ingress/values.yaml
+++ b/examples/alb-ingress/values.yaml
@@ -63,7 +63,7 @@ additionalManifests:
                 pathType: Prefix
                 backend:
                   service:
-                    name: '{{ include "clickstack.fullname" . }}-app'
+                    name: '{{ include "clickstack.hyperdx.fullname" . }}'
                     port:
                       name: app
 
@@ -101,7 +101,7 @@ additionalManifests:
       scaleTargetRef:
         apiVersion: apps/v1
         kind: Deployment
-        name: '{{ include "clickstack.fullname" . }}-app'
+        name: '{{ include "clickstack.hyperdx.fullname" . }}'
       minReplicas: 2
       maxReplicas: 10
       metrics:


### PR DESCRIPTION
## Summary

- Adds a `clickstack.hyperdx.fullname` helper template that omits the `-app` suffix when `fullnameOverride` is set, giving users full control over resource naming
- Default behavior (no `fullnameOverride`) is unchanged -- the `-app` suffix is still appended for backward compatibility
- Updates all templates, values, and examples that previously hardcoded `-app` to use the new helper

Closes HDX-3850

## Test plan

- [x] All 152 existing helm-unittest tests pass (25 suites)
- [x] ALB example values render cleanly via `helm template`
- [x] New test case asserts `fullnameOverride` produces name without `-app`
- [x] Existing `fullnameOverride` test updated to expect name without `-app`
- [x] CI: Helm Chart Tests workflow passes
- [x] CI: Helm Chart Integration Test workflow passes


Made with [Cursor](https://cursor.com)