### PR TITLE
chore: update default sources based on new schema changes

### DIFF
--- a/.changeset/update-default-sources.md
+++ b/.changeset/update-default-sources.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+chore: update default sources based on new schema changes

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -108,7 +108,7 @@ hyperdx:
             "tableName": "otel_logs"
           },
           "kind": "log",
-          "timestampValueExpression": "TimestampTime",
+          "timestampValueExpression": "Timestamp",
           "name": "Logs",
           "displayedTimestampValueExpression": "Timestamp",
           "implicitColumnExpression": "Body",


### PR DESCRIPTION
New schema is introduced in https://github.com/hyperdxio/hyperdx/pull/2125

The schema removes the `TimestampTime` column, so default sources should be updated appropriately