### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ClickHouse/clickstack


### PR DESCRIPTION
Makes `@ClickHouse/clickstack` the default code owners for all paths in this repository.

## Changes
- Adds `.github/CODEOWNERS` with a catch-all rule assigning ownership of all files to the clickstack team.