### PR TITLE
feat: expose hyperdx initContainers, volumes, volumeMounts passthrough

### DIFF
--- a/.changeset/expose-hyperdx-deployment-hooks.md
+++ b/.changeset/expose-hyperdx-deployment-hooks.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": minor
+---
+
+Expose hyperdx.deployment.initContainers, volumes, and volumeMounts passthrough fields for injecting additional init containers, pod-level volumes, and container-level volume mounts into the HyperDX Deployment. Defaults are empty lists, so existing values files render unchanged.

--- a/charts/clickstack/templates/hyperdx/deployment.yaml
+++ b/charts/clickstack/templates/hyperdx/deployment.yaml
@@ -52,12 +52,21 @@ spec:
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
       {{- end }}
-      {{- if .Values.mongodb.enabled }}
+      {{- if or .Values.mongodb.enabled .Values.hyperdx.deployment.initContainers }}
       initContainers:
+        {{- if .Values.mongodb.enabled }}
         - name: wait-for-mongodb
           image: {{ .Values.hyperdx.deployment.waitForMongodb.image }}
           imagePullPolicy: {{ .Values.hyperdx.deployment.waitForMongodb.pullPolicy }}
           command: ['sh', '-c', 'until nc -z {{ include "clickstack.mongodb.svc" . }} 27017; do echo waiting for mongodb; sleep 2; done;']
+        {{- end }}
+        {{- with .Values.hyperdx.deployment.initContainers }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- end }}
+      {{- with .Values.hyperdx.deployment.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
         - name: app
@@ -93,6 +102,10 @@ spec:
             periodSeconds: {{ .Values.hyperdx.deployment.readinessProbe.periodSeconds }}
             timeoutSeconds: {{ .Values.hyperdx.deployment.readinessProbe.timeoutSeconds }}
             failureThreshold: {{ .Values.hyperdx.deployment.readinessProbe.failureThreshold }}
+          {{- end }}
+          {{- with .Values.hyperdx.deployment.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
           {{- end }}
           envFrom:
             - configMapRef:

--- a/charts/clickstack/tests/hyperdx-deployment_test.yaml
+++ b/charts/clickstack/tests/hyperdx-deployment_test.yaml
@@ -152,6 +152,134 @@ tests:
           path: spec.template.spec.initContainers[0].imagePullPolicy
           value: Always
 
+  - it: should not include initContainers when mongodb is disabled and no user init containers are provided
+    set:
+      mongodb:
+        enabled: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.initContainers
+
+  - it: should render only user-provided initContainers when mongodb is disabled
+    set:
+      mongodb:
+        enabled: false
+      hyperdx:
+        deployment:
+          initContainers:
+            - name: fetch-cert
+              image: busybox:1.36.1
+              command: ['sh', '-c', 'wget -O /certs/bundle.pem https://example.com/bundle.pem']
+              volumeMounts:
+                - name: certs
+                  mountPath: /certs
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 1
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: fetch-cert
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: busybox:1.36.1
+      - equal:
+          path: spec.template.spec.initContainers[0].volumeMounts[0].mountPath
+          value: /certs
+
+  - it: should render wait-for-mongodb first then user initContainers when both are set
+    set:
+      mongodb:
+        enabled: true
+      hyperdx:
+        deployment:
+          initContainers:
+            - name: fetch-cert
+              image: busybox:1.36.1
+              command: ['sh', '-c', 'wget -O /certs/bundle.pem https://example.com/bundle.pem']
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.initContainers
+          count: 2
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: wait-for-mongodb
+      - equal:
+          path: spec.template.spec.initContainers[1].name
+          value: fetch-cert
+
+  - it: should not include volumes by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.volumes
+
+  - it: should render user-provided volumes when set
+    set:
+      hyperdx:
+        deployment:
+          volumes:
+            - name: certs
+              emptyDir: {}
+            - name: saml-cert
+              configMap:
+                name: hyperdx-saml-cert
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 2
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: certs
+      - isSubset:
+          path: spec.template.spec.volumes[0]
+          content:
+            emptyDir: {}
+      - equal:
+          path: spec.template.spec.volumes[1].name
+          value: saml-cert
+      - equal:
+          path: spec.template.spec.volumes[1].configMap.name
+          value: hyperdx-saml-cert
+
+  - it: should not include volumeMounts on the app container by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].volumeMounts
+
+  - it: should render user-provided volumeMounts on the app container including subPath and readOnly
+    set:
+      hyperdx:
+        deployment:
+          volumeMounts:
+            - name: certs
+              mountPath: /certs
+            - name: saml-cert
+              mountPath: /etc/hyperdx/idp-cert.pem
+              subPath: idp-cert.pem
+              readOnly: true
+    asserts:
+      - lengthEqual:
+          path: spec.template.spec.containers[0].volumeMounts
+          count: 2
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].name
+          value: certs
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: /certs
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: saml-cert
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].mountPath
+          value: /etc/hyperdx/idp-cert.pem
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].subPath
+          value: idp-cert.pem
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].readOnly
+          value: true
+
   - it: should include livenessProbe with default values when enabled
     asserts:
       - isSubset:

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -80,6 +80,13 @@ hyperdx:
     annotations: {}
     labels: {}
     env: []
+    # Additional init containers to run before the HyperDX container starts.
+    # Useful for fetching certificates, warming caches, or other startup tasks.
+    initContainers: []
+    # Additional volumes to attach to the pod.
+    volumes: []
+    # Additional volume mounts to apply to the HyperDX container.
+    volumeMounts: []
     waitForMongodb:
       image: "busybox@sha256:1fcf5df59121b92d61e066df1788e8df0cc35623f5d62d9679a41e163b6a0cdb"
       pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

Adds three optional passthrough fields under `hyperdx.deployment` so users can inject standard Kubernetes pod-spec extension into the HyperDX Deployment

  - `hyperdx.deployment.initContainers`: appended after `wait-for-mongodb` when `mongodb.enabled` is true; rendered standalone when MongoDB is disabled
  - `hyperdx.deployment.volumes`: rendered at `spec.template.spec.volumes`
  - `hyperdx.deployment.volumeMounts`: rendered on the `app` container

Unit tests included

## Motivation

Several common deployment patterns currently require forking this chart, for eg:

  - Fetching a TLS CA bundle at startup (e.g., AWS RDS/DocumentDB CA via a small init container)
  - Mounting SAML IdP signing certs from a ConfigMap at `/etc/hyperdx/idp-cert.pem`
  - Attaching external secrets, license files, or config snippets from ConfigMaps/Secrets

Exposing these standard hooks keeps these workflows in user values files instead of chart forks.

## Backward compatibility

Backward compatible. Defaults are empty lists. The existing `should include initContainers when mongodb.enabled is true` test continues to pass unchanged, confirming no behavior change for current users.

## Changeset included.