### PR TITLE
fix: align otel-collector image tag with chart appVersion

### DIFF
--- a/.github/workflows/update-app-version.yml
+++ b/.github/workflows/update-app-version.yml
@@ -25,6 +25,10 @@ jobs:
         run: |
           sed -i "s/^appVersion: .*/appVersion: ${{ github.event.inputs.tag }}/" charts/clickstack/Chart.yaml
 
+      - name: Update otel-collector image tag in values.yaml
+        run: |
+          sed -i '/clickstack-otel-collector/{n;s/tag: "[^"]*"/tag: "${{ github.event.inputs.tag }}"/}' charts/clickstack/values.yaml
+
       - name: Create changeset
         run: |
           mkdir -p .changeset
@@ -43,8 +47,9 @@ jobs:
           commit-message: "chore: Update appVersion to ${{ github.event.inputs.tag }}"
           title: "Update appVersion to ${{ github.event.inputs.tag }}"
           body: |
-            This PR updates the appVersion in Chart.yaml to `${{ github.event.inputs.tag }}`.
-            
+            This PR updates the appVersion in Chart.yaml to `${{ github.event.inputs.tag }}` and aligns the otel-collector image tag in values.yaml.
+
             - Updated `charts/clickstack/Chart.yaml`
+            - Updated `otel-collector.image.tag` in `charts/clickstack/values.yaml`
           branch: update-app-version-${{ github.event.inputs.tag }}
           delete-branch: true

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -371,7 +371,7 @@ otel-collector:
   mode: deployment
   image:
     repository: docker.clickhouse.com/clickhouse/clickstack-otel-collector
-    tag: "2.19.0"
+    tag: "2.27.0"
   extraEnvsFrom:
     - configMapRef:
         name: clickstack-config


### PR DESCRIPTION
## Problem

The `clickstack` chart 3.0.0 ships `appVersion: 2.27.0` but pins the
otel-collector image at `tag: "2.19.0"` in `values.yaml`. The 2.27.0
app pushes an OpAMP config to the collector containing a `json:` key in
the ClickHouse exporter, which the 2.19.0 binary rejects:

```console
'clickhouseexporter.Config' has invalid keys: json
```

This causes an immediate `CrashLoopBackOff` on `my-clickstack-otel-collector`,
making port 4318 unavailable to any downstream collectors.

Related: #219

## Changes

- `charts/clickstack/values.yaml`: bump `otel-collector.image.tag` from `2.19.0` to `2.27.0` to match `appVersion`
- `.github/workflows/update-app-version.yml`: add a step that updates the image tag in `values.yaml` alongside `Chart.yaml` on every future version bump, preventing this drift from recurring