### PR TITLE
ci: declare workflow-level `contents: read` on chart-test and helm-test

### DIFF
--- a/.github/workflows/chart-test.yml
+++ b/.github/workflows/chart-test.yml
@@ -9,6 +9,9 @@ on:
     - cron: "0 2 * * *"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   discover:
     runs-on: ubuntu-latest

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   helm-unittest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Both workflows just run helm chart tests; no GitHub API writes from the workflows.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.