### PR TITLE
feat: support custom command and args for container

### DIFF
--- a/.changeset/goofy-beers-punch.md
+++ b/.changeset/goofy-beers-punch.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": minor
+---
+
+feat: support custom command and args for container

--- a/charts/clickstack/templates/hyperdx/deployment.yaml
+++ b/charts/clickstack/templates/hyperdx/deployment.yaml
@@ -72,6 +72,14 @@ spec:
         - name: app
           image: "{{ .Values.hyperdx.deployment.image.repository }}:{{ .Values.hyperdx.deployment.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.hyperdx.deployment.image.pullPolicy }}
+          {{- if .Values.hyperdx.deployment.command }}
+          command: 
+            {{- toYaml .Values.hyperdx.deployment.command | nindent 12 }}
+          {{- end }}
+          {{- if .Values.hyperdx.deployment.args }}
+          args: 
+            {{- toYaml .Values.hyperdx.deployment.args | nindent 12 }}
+          {{- end }}
           ports:
             - name: app-port
               containerPort: {{ .Values.hyperdx.ports.app }}

--- a/charts/clickstack/tests/hyperdx-deployment_test.yaml
+++ b/charts/clickstack/tests/hyperdx-deployment_test.yaml
@@ -91,6 +91,47 @@ tests:
             name: ANOTHER_ENV
             value: "another-value"
 
+  - it: should not include command and args by default
+    asserts:
+      - isNull:
+          path: spec.template.spec.containers[0].command
+      - isNull:
+          path: spec.template.spec.containers[0].args
+
+  - it: should render custom command when provided
+    set:
+      hyperdx:
+        deployment:
+          command:
+            - sh
+            - -c
+            - "echo hello"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].command[0]
+          value: sh
+      - equal:
+          path: spec.template.spec.containers[0].command[1]
+          value: -c
+      - equal:
+          path: spec.template.spec.containers[0].command[2]
+          value: "echo hello"
+
+  - it: should render custom args when provided
+    set:
+      hyperdx:
+        deployment:
+          args:
+            - "--env"
+            - "prod"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].args[0]
+          value: --env
+      - equal:
+          path: spec.template.spec.containers[0].args[1]
+          value: prod
+
   - it: should expose OpAMP container port with default values
     asserts:
       - equal:

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -59,6 +59,8 @@ hyperdx:
       repository: docker.hyperdx.io/hyperdx/hyperdx
       tag:
       pullPolicy: IfNotPresent
+    command: []
+    args: []
     replicas: 1     # ignored when autoscaling.enabled is true (HPA manages replicas)
     resources: {}
     livenessProbe:


### PR DESCRIPTION
This PR resolves the limitation where users cannot override the container's default entrypoint and arguments via Helm values. 

## Problem
Currently, the Deployment template hardcodes or relies entirely on the Docker image's built-in `ENTRYPOINT` and `CMD`. In enterprise or debugging scenarios (as reported in hyperdxio/hyperdx#1329), users frequently need to pass custom flags, inject debugging tools, or alter the container startup behavior. Without `command` and `args` support in `values.yaml`, this is impossible without fracturing the chart or maintaining a custom fork.

## Backward Compatibility
This change is **100% backward compatible** and introduces **zero breaking changes** for existing deployments due to the following safeguards:

1. **Empty Defaults:** In `values.yaml`, both `command` and `args` are initialized as empty lists (`[]`).
2. **Conditional Rendering:** In `deployment.yaml`, we use Helm's `{{- if ... }}` blocks. If a user upgrades their existing release without providing these values, the template simply skips rendering the fields entirely. The container will continue to fall back to the image's original behavior exactly as before.
