### PR TITLE
fix(clickstack-operators): bump clickhouse-operator-helm dep to >=0.0.5

### DIFF
--- a/.changeset/bump-clickhouse-operator-helm.md
+++ b/.changeset/bump-clickhouse-operator-helm.md
@@ -1,0 +1,15 @@
+---
+"helm-charts": minor
+---
+
+fix(clickstack-operators): bump clickhouse-operator-helm dependency to `>=0.0.5, <0.1.0`
+
+The operator was pinned to v0.0.2 by a stale `Chart.lock`, not by the `~0.0.2` constraint — under Masterminds semver `~0.0.2` already permits the full `>=0.0.2, <0.1.0` range. Widening the constraint to `>=0.0.5, <0.1.0` and regenerating the lock moves the operator to the latest 0.0.x (currently v0.0.6), which includes the changes introduced in v0.0.5:
+
+- New CRD schema with the `spec.podDisruptionBudget` field on both `ClickHouseCluster` and `KeeperCluster` (lets users override the auto-generated PDB).
+- Smart default for `ClickHouseCluster` with `replicas <= 1`: `maxUnavailable=1` instead of `minAvailable=1`, so single-replica deployments no longer deadlock on node drains.
+- RBAC additions (e.g. `Jobs` informer) required by the newer controller manager.
+
+Users on `clickstack-operators` v1.0.0 cannot benefit from any of these because the published chart's lock pins the dependency to v0.0.2, and the newer binary cannot run against v0.0.2's RBAC or CRD schema.
+
+**New prerequisite:** the operator now renders cert-manager `Certificate`/`Issuer` resources for its webhook and metrics TLS, so **cert-manager must be installed in the cluster before installing `clickstack-operators`** (see the Quick Start). To opt out, set `clickhouse-operator.certManager.enabled=false`.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 helm repo add clickstack https://clickhouse.github.io/ClickStack-helm-charts
 helm repo update
 
+# Prerequisite: cert-manager (the ClickHouse operator uses it for webhook + metrics TLS)
+helm repo add jetstack https://charts.jetstack.io
+helm install cert-manager jetstack/cert-manager \
+  --namespace cert-manager --create-namespace \
+  --version v1.21.0 --set crds.enabled=true --wait
+
 # Step 1: Install operators and CRDs
 helm install clickstack-operators clickstack/clickstack-operators
 

--- a/charts/clickstack-operators/Chart.lock
+++ b/charts/clickstack-operators/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.7.0
 - name: clickhouse-operator-helm
   repository: oci://ghcr.io/clickhouse
-  version: 0.0.2
-digest: sha256:1daf572004da83b1836c8867f11198530652fee6905d4786a2d5eef87bc611cd
-generated: "2026-03-04T16:52:51.068188-06:00"
+  version: 0.0.6
+digest: sha256:07f7e26310152ee102b4d1c8d32e6211dcfaf2abdf240a1769f5490f0de2ebd7
+generated: "2026-06-30T10:56:03.8831264+02:00"

--- a/charts/clickstack-operators/Chart.yaml
+++ b/charts/clickstack-operators/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   installing clickstack/clickstack to ensure CRDs are registered.
 home: https://clickhouse.com/docs/use-cases/observability/clickstack
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "1.0.0"
 dependencies:
   - name: mongodb-kubernetes
@@ -13,6 +13,6 @@ dependencies:
     repository: https://mongodb.github.io/helm-charts
     alias: mongodb-operator
   - name: clickhouse-operator-helm
-    version: "~0.0.2"
+    version: ">=0.0.5, <0.1.0"
     repository: oci://ghcr.io/clickhouse
     alias: clickhouse-operator

--- a/integration-tests/README.md
+++ b/integration-tests/README.md
@@ -68,7 +68,7 @@ For each suite, the harness (`run-suite.sh`) runs these steps in order:
 2. Create Kind cluster (uses `kind-config.yaml` if present)
 3. Install local-path-provisioner (if `needs_local_storage: true`)
 4. Build Helm chart dependencies
-5. Install clickstack-operators (if `needs_operators: true`)
+5. Install cert-manager, then clickstack-operators (if `needs_operators: true`)
 6. Run `prereq.sh` (if present and executable)
 7. `helm install` with `values.yaml` and configured timeout
 8. Run `assert.sh`

--- a/integration-tests/run-suite.sh
+++ b/integration-tests/run-suite.sh
@@ -60,6 +60,19 @@ helm dependency build "$REPO_ROOT/charts/clickstack"
 echo ""
 
 if [ "$NEEDS_OPERATORS" = "true" ]; then
+    # clickhouse-operator (>=0.0.5) renders cert-manager Certificate/Issuer resources, so cert-manager
+    # must be installed first. Use Helm --wait: its startupapicheck hook blocks until the webhook is
+    # actually serving, avoiding a race where the operator's admission calls hit it too early.
+    CERT_MANAGER_VERSION="v1.21.0"
+    echo "--- Installing cert-manager ${CERT_MANAGER_VERSION} ---"
+    helm repo add jetstack https://charts.jetstack.io 2>/dev/null || true
+    helm install cert-manager jetstack/cert-manager \
+        --namespace cert-manager --create-namespace \
+        --version "${CERT_MANAGER_VERSION}" \
+        --set crds.enabled=true \
+        --wait --timeout=5m
+    echo ""
+
     echo "--- Installing clickstack-operators ---"
     helm install clickstack-operators "$REPO_ROOT/charts/clickstack-operators" --timeout=5m
     echo "Waiting for CRDs..."


### PR DESCRIPTION
## Problem

The `clickstack-operators` chart at v1.0.0 declares its `clickhouse-operator-helm` dependency as `~0.0.2`. In Helm's Masterminds semver implementation, the tilde range for pre-1.0 patch-level versions is interpreted narrowly as `>=0.0.2 <0.0.3` — so this dep resolves only to **v0.0.2** of the operator chart, even though newer 0.0.x releases (v0.0.3, v0.0.4, v0.0.5) exist.

Consumers of `clickstack-operators` v1.0.0 are effectively pinned to operator v0.0.2 and miss every fix since then. In particular, v0.0.5 ships:

- New CRD schema field `spec.podDisruptionBudget` on both `ClickHouseCluster` and `KeeperCluster` (lets users override the auto-generated PDB).
- Smart default for `ClickHouseCluster` with `replicas <= 1`: `maxUnavailable=1` (instead of `minAvailable=1`) so single-replica clusters do not deadlock on voluntary disruption (e.g. node drains, upgrades).
- RBAC additions (notably the `Jobs` informer the v0.0.5 controller manager requires).

We hit this in production: a single-replica deployment of ClickStack on AKS got stuck on a node-pool VM resize because the v0.0.2 operator generated PDBs that no eviction could satisfy (`minAvailable=1` on a 1-replica ClickHouse, `maxUnavailable=0` on a 1-replica Keeper). Bumping the wrapper chart's operator image alone is not enough — the v0.0.5 binary crashloops against v0.0.2's RBAC/CRDs.

## Fix

Widen the dependency constraint so the chart pulls v0.0.5 (and stays compatible with future 0.0.x releases):

```yaml
# charts/clickstack-operators/Chart.yaml
- name: clickhouse-operator-helm
  version: ">=0.0.5, <0.1.0"   # was: "~0.0.2"
```

This pulls operator v0.0.5 + its matching CRDs + matching RBAC together, as one consistent set.

## Verification

```bash
$ helm dependency build charts/clickstack-operators
Pulled: ghcr.io/clickhouse/clickhouse-operator-helm:0.0.5

$ helm template clickstack-operators charts/clickstack-operators | grep -c "^kind:"
29
```

Resolves cleanly, no template errors, all expected resources render.

## Changeset

Added `.changeset/bump-clickhouse-operator-helm.md` (minor bump) describing the user-visible change for the next release.

## Notes for adopters

Existing installations have CRDs with `helm.sh/resource-policy: keep` (from the original install), which prevents Helm from updating them on upgrade. After this change merges and a new chart release is published, adopters upgrading from v1.0.0 will need a one-time `kubectl apply -f` of the new CRDs (or remove the keep annotation) to pick up the new schema. This is unrelated to this PR but worth mentioning in the release notes.