### PR TITLE
ci: restrict helm-test workflow permissions to read-only

### DIFF
--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   helm-unittest:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds an explicit least-privilege `permissions:` block to `.github/workflows/helm-test.yaml`. The job only reads the repository, so `contents: read` is sufficient; today the workflow inherits whatever the repository default grants, which is broader than it needs. This is one of the checks OpenSSF Scorecard flags under [Token-Permissions](https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions).