### PR TITLE
fix: align otel-collector image tag with appVersion

### DIFF
--- a/.changeset/align-otel-collector-tag.md
+++ b/.changeset/align-otel-collector-tag.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+fix: align otel-collector image tag with chart appVersion

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -60,6 +60,9 @@ jobs:
             exit 1
           fi
 
+          EXPECTED_COLLECTOR_IMAGE="image: \"docker.clickhouse.com/clickhouse/clickstack-otel-collector:${APP_VERSION}\""
+          helm template clickstack-version-check charts/clickstack | grep -F "$EXPECTED_COLLECTOR_IMAGE"
+
       - name: Validate example values render
         run: |
           helm template clickstack-example charts/clickstack \

--- a/.github/workflows/helm-test.yaml
+++ b/.github/workflows/helm-test.yaml
@@ -37,6 +37,29 @@ jobs:
           helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
           helm dependency build charts/clickstack
 
+      - name: Validate appVersion matches collector image tag
+        run: |
+          set -euo pipefail
+          APP_VERSION=$(awk '$1 == "appVersion:" { print $2 }' charts/clickstack/Chart.yaml)
+          COLLECTOR_TAG=$(awk '
+            $1 == "repository:" && $2 == "docker.clickhouse.com/clickhouse/clickstack-otel-collector" { in_image = 1; next }
+            in_image && $1 == "tag:" {
+              gsub(/"/, "", $2)
+              print $2
+              exit
+            }
+          ' charts/clickstack/values.yaml)
+
+          if [ -z "$APP_VERSION" ] || [ -z "$COLLECTOR_TAG" ]; then
+            echo "Could not read appVersion or otel-collector image tag"
+            exit 1
+          fi
+
+          if [ "$APP_VERSION" != "$COLLECTOR_TAG" ]; then
+            echo "appVersion ($APP_VERSION) does not match otel-collector.image.tag ($COLLECTOR_TAG)"
+            exit 1
+          fi
+
       - name: Validate example values render
         run: |
           helm template clickstack-example charts/clickstack \

--- a/.github/workflows/update-app-version.yml
+++ b/.github/workflows/update-app-version.yml
@@ -26,14 +26,38 @@ jobs:
           TAG: ${{ github.event.inputs.tag }}
         run: |
           set -euo pipefail
-          sed -i "s/^appVersion: .*/appVersion: $TAG/" charts/clickstack/Chart.yaml
+          tmp=$(mktemp)
+          awk -v tag="$TAG" '
+            /^appVersion:/ { $0 = "appVersion: " tag; updated = 1 }
+            { print }
+            END { exit updated ? 0 : 1 }
+          ' charts/clickstack/Chart.yaml > "$tmp"
+          mv "$tmp" charts/clickstack/Chart.yaml
 
       - name: Update otel-collector image tag in values.yaml
         env:
           TAG: ${{ github.event.inputs.tag }}
         run: |
           set -euo pipefail
-          sed -i '/clickstack-otel-collector/{n;s/tag: "[^"]*"/tag: "'"$TAG"'"/}' charts/clickstack/values.yaml
+          tmp=$(mktemp)
+          awk -v tag="$TAG" '
+            /repository: docker\.clickhouse\.com\/clickhouse\/clickstack-otel-collector[[:space:]]*$/ {
+              in_collector_image = 1
+              print
+              next
+            }
+            in_collector_image && /^[[:space:]]{0,2}[[:alnum:]_-]+:/ {
+              in_collector_image = 0
+            }
+            in_collector_image && /^[[:space:]]*tag:/ {
+              sub(/tag: .*/, "tag: \"" tag "\"")
+              updated = 1
+              in_collector_image = 0
+            }
+            { print }
+            END { exit updated ? 0 : 1 }
+          ' charts/clickstack/values.yaml > "$tmp"
+          mv "$tmp" charts/clickstack/values.yaml
           awk -v tag="$TAG" '
             /repository: docker\.clickhouse\.com\/clickhouse\/clickstack-otel-collector/ { in_image = 1; next }
             in_image && /^[[:space:]]*tag:/ {

--- a/.github/workflows/update-app-version.yml
+++ b/.github/workflows/update-app-version.yml
@@ -22,12 +22,26 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Update appVersion in Chart.yaml
+        env:
+          TAG: ${{ github.event.inputs.tag }}
         run: |
-          sed -i "s/^appVersion: .*/appVersion: ${{ github.event.inputs.tag }}/" charts/clickstack/Chart.yaml
+          set -euo pipefail
+          sed -i "s/^appVersion: .*/appVersion: $TAG/" charts/clickstack/Chart.yaml
 
       - name: Update otel-collector image tag in values.yaml
+        env:
+          TAG: ${{ github.event.inputs.tag }}
         run: |
-          sed -i '/clickstack-otel-collector/{n;s/tag: "[^"]*"/tag: "${{ github.event.inputs.tag }}"/}' charts/clickstack/values.yaml
+          set -euo pipefail
+          sed -i '/clickstack-otel-collector/{n;s/tag: "[^"]*"/tag: "'"$TAG"'"/}' charts/clickstack/values.yaml
+          awk -v tag="$TAG" '
+            /repository: docker\.clickhouse\.com\/clickhouse\/clickstack-otel-collector/ { in_image = 1; next }
+            in_image && /^[[:space:]]*tag:/ {
+              if ($0 ~ "tag: \"" tag "\"") found = 1
+              in_image = 0
+            }
+            END { exit found ? 0 : 1 }
+          ' charts/clickstack/values.yaml
 
       - name: Create changeset
         run: |

--- a/.github/workflows/update-app-version.yml
+++ b/.github/workflows/update-app-version.yml
@@ -25,6 +25,10 @@ jobs:
         run: |
           sed -i "s/^appVersion: .*/appVersion: ${{ github.event.inputs.tag }}/" charts/clickstack/Chart.yaml
 
+      - name: Update otel-collector image tag in values.yaml
+        run: |
+          sed -i '/clickstack-otel-collector/{n;s/tag: "[^"]*"/tag: "${{ github.event.inputs.tag }}"/}' charts/clickstack/values.yaml
+
       - name: Create changeset
         run: |
           mkdir -p .changeset
@@ -43,8 +47,9 @@ jobs:
           commit-message: "chore: Update appVersion to ${{ github.event.inputs.tag }}"
           title: "Update appVersion to ${{ github.event.inputs.tag }}"
           body: |
-            This PR updates the appVersion in Chart.yaml to `${{ github.event.inputs.tag }}`.
+            This PR updates the appVersion in Chart.yaml to `${{ github.event.inputs.tag }}` and aligns the otel-collector image tag in values.yaml.
             
             - Updated `charts/clickstack/Chart.yaml`
+            - Updated `otel-collector.image.tag` in `charts/clickstack/values.yaml`
           branch: update-app-version-${{ github.event.inputs.tag }}
           delete-branch: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -163,5 +163,5 @@ tests:
 - Unit tests: `charts/clickstack/tests/*_test.yaml`
 - Integration suites: `integration-tests/*/`
 - Example values: `examples/*/values.yaml`
-- Version sync script: `scripts/update-chart-versions.js`
+- Chart version sync script: `scripts/update-chart-versions.js`
 - Smoke test: `scripts/smoke-test.sh`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,7 +153,7 @@ tests:
 | Helm Chart Tests | `helm-test.yaml` | push/PR to main | Unit tests + example validation |
 | Integration Test | `chart-test.yml` | push/PR/nightly | Kind-based integration suites |
 | Release | `release.yml` | after tests pass on main | Changeset version + chart release |
-| Update App Version | `update-app-version.yml` | workflow_dispatch | Bump `appVersion` in Chart.yaml |
+| Update App Version | `update-app-version.yml` | workflow_dispatch | Bump `appVersion` in Chart.yaml and align `otel-collector.image.tag` in values.yaml |
 
 ## Key File Locations
 

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -371,7 +371,7 @@ otel-collector:
   mode: deployment
   image:
     repository: docker.clickhouse.com/clickhouse/clickstack-otel-collector
-    tag: "2.19.0"
+    tag: "2.28.0"
   extraEnvsFrom:
     - configMapRef:
         name: clickstack-config
@@ -412,4 +412,3 @@ otel-collector:
       enabled: false
     zipkin:
       enabled: false
-


### PR DESCRIPTION
## Problem

The `clickstack` chart on current `main` has `appVersion: 2.28.0`, but the default bundled collector image is still pinned to `docker.clickhouse.com/clickhouse/clickstack-otel-collector:2.19.0`.

As reported in #219, the older collector rejects the ClickHouse exporter `json` key pushed by newer ClickStack app versions:

```console
'clickhouseexporter.Config' has invalid keys: json
```

That causes the default collector pod to crash loop.

## Changes

- Bump the default `otel-collector.image.tag` from `2.19.0` to `2.28.0`, matching the current chart `appVersion`.
- Update the appVersion workflow so future appVersion bumps also update the collector image tag.
- Add a patch changeset for the chart fix.

## Verification

```console
helm dependency build charts/clickstack
helm lint charts/clickstack
helm template smoke charts/clickstack --set clickhouse.persistence.enabled=false --set mongodb.persistence.enabled=false | rg 'clickstack-otel-collector|hyperdx:2\.28\.0|2\.19\.0|2\.28\.0'
```

The rendered default collector image is now:

```yaml
image: "docker.clickhouse.com/clickhouse/clickstack-otel-collector:2.28.0"
```

and the HyperDX app image also renders as `2.28.0`.

Fixes #219.

Related to #220, which has the same root-cause fix but is currently behind `main` and still targets the previous `2.27.0` appVersion.