### PR TITLE
fix: align otel-collector image tag with appVersion

### DIFF
--- a/.changeset/align-otel-collector-tag.md
+++ b/.changeset/align-otel-collector-tag.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+fix: align otel-collector image tag with chart appVersion

--- a/.github/workflows/update-app-version.yml
+++ b/.github/workflows/update-app-version.yml
@@ -25,6 +25,10 @@ jobs:
         run: |
           sed -i "s/^appVersion: .*/appVersion: ${{ github.event.inputs.tag }}/" charts/clickstack/Chart.yaml
 
+      - name: Update otel-collector image tag in values.yaml
+        run: |
+          sed -i '/clickstack-otel-collector/{n;s/tag: "[^"]*"/tag: "${{ github.event.inputs.tag }}"/}' charts/clickstack/values.yaml
+
       - name: Create changeset
         run: |
           mkdir -p .changeset
@@ -43,8 +47,9 @@ jobs:
           commit-message: "chore: Update appVersion to ${{ github.event.inputs.tag }}"
           title: "Update appVersion to ${{ github.event.inputs.tag }}"
           body: |
-            This PR updates the appVersion in Chart.yaml to `${{ github.event.inputs.tag }}`.
+            This PR updates the appVersion in Chart.yaml to `${{ github.event.inputs.tag }}` and aligns the otel-collector image tag in values.yaml.
             
             - Updated `charts/clickstack/Chart.yaml`
+            - Updated `otel-collector.image.tag` in `charts/clickstack/values.yaml`
           branch: update-app-version-${{ github.event.inputs.tag }}
           delete-branch: true

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -371,7 +371,7 @@ otel-collector:
   mode: deployment
   image:
     repository: docker.clickhouse.com/clickhouse/clickstack-otel-collector
-    tag: "2.19.0"
+    tag: "2.28.0"
   extraEnvsFrom:
     - configMapRef:
         name: clickstack-config
@@ -412,4 +412,3 @@ otel-collector:
       enabled: false
     zipkin:
       enabled: false
-


### PR DESCRIPTION
## Problem

The `clickstack` chart on current `main` has `appVersion: 2.28.0`, but the default bundled collector image is still pinned to `docker.clickhouse.com/clickhouse/clickstack-otel-collector:2.19.0`.

As reported in #219, the older collector rejects the ClickHouse exporter `json` key pushed by newer ClickStack app versions:

```console
'clickhouseexporter.Config' has invalid keys: json
```

That causes the default collector pod to crash loop.

## Changes

- Bump the default `otel-collector.image.tag` from `2.19.0` to `2.28.0`, matching the current chart `appVersion`.
- Update the appVersion workflow so future appVersion bumps also update the collector image tag.
- Add a patch changeset for the chart fix.

## Verification

```console
helm lint charts/clickstack
helm template smoke charts/clickstack --set clickhouse.persistence.enabled=false --set mongodb.persistence.enabled=false | rg 'clickstack-otel-collector|hyperdx:2\.28\.0|2\.19\.0|2\.28\.0'
```

The rendered default collector image is now:

```yaml
image: "docker.clickhouse.com/clickhouse/clickstack-otel-collector:2.28.0"
```

Fixes #219.

Related to #220. Replaces closed #233 with only the original first commit.