### PR TITLE
[HDX] Add external-contributor-alerts GitHub workflow

### DIFF
--- a/.github/workflows/external-contributor-alerts.yml
+++ b/.github/workflows/external-contributor-alerts.yml
@@ -1,0 +1,72 @@
+name: Alert on external contributions
+
+on:
+  issues:
+    types: [opened, reopened]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: external-contrib-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        env:
+          SLACK_WEBHOOK_OSS_PRS: ${{ secrets.SLACK_WEBHOOK_OSS_PRS }}
+        with:
+          script: |
+            const LABEL = 'external';
+            const item = context.payload.issue ?? context.payload.pull_request;
+            if (!item) return;
+
+            if (item.draft) { core.info(`Skipping draft PR #${item.number}`); return; }
+            if (item.user?.type === 'Bot') { core.info(`Skipping bot ${item.user?.login}`); return; }
+            const INTERNAL = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            if (INTERNAL.includes(item.author_association)) {
+              core.info(`#${item.number} by ${item.user?.login} is internal (${item.author_association}); skipping.`);
+              return;
+            }
+            if (item.labels?.some(l => l.name === LABEL)) { core.info(`#${item.number} already handled.`); return; }
+
+            const { owner, repo } = context.repo;
+            const webhook = process.env.SLACK_WEBHOOK_OSS_PRS;
+            if (!webhook) {
+              core.warning('SLACK_WEBHOOK_OSS_PRS not set — no alert sent and not labeled (will retry on next event).');
+              return;
+            }
+            const kind = context.payload.pull_request ? 'PR' : 'issue';
+            const text = `:sparkles: *New external ${kind}* in \`${owner}/${repo}\`\n`
+              + `<${item.html_url}|#${item.number}: ${item.title}>\n`
+              + `by \`${item.user.login}\` (${item.author_association})`;
+            let delivered = false;
+            try {
+              const res = await fetch(webhook, {
+                method: 'POST', headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ blocks: [{ type: 'section', text: { type: 'mrkdwn', text } }] }),
+              });
+              delivered = res.ok;
+              if (!delivered) core.setFailed(`Slack post failed (${res.status}); leaving #${item.number} unlabeled to retry.`);
+            } catch (e) {
+              core.setFailed(`Slack post errored (${e.message}); leaving #${item.number} unlabeled to retry.`);
+            }
+            if (!delivered) return;
+
+            try {
+              await github.rest.issues.createLabel({
+                owner, repo, name: LABEL, color: 'D4C5F9',
+                description: 'Opened by an external contributor',
+              });
+              core.info(`Created '${LABEL}' label.`);
+            } catch (e) {
+              if (e.status !== 422) throw e;
+            }
+            await github.rest.issues.addLabels({ owner, repo, issue_number: item.number, labels: [LABEL] });
+            core.info(`Alerted Slack and labeled #${item.number} (${item.author_association}).`);


### PR DESCRIPTION
Issues and pull requests opened by external contributors are now surfaced automatically: the workflow posts a Slack alert to the `SLACK_WEBHOOK_OSS_PRS` webhook and applies an `external` label so each item is announced exactly once. Internal authors (OWNER/MEMBER/COLLABORATOR), bots, and draft PRs are skipped.

Ported verbatim from the hyperdx repo. It uses `pull_request_target` so it works on fork PRs, and `actions/github-script@v9`, matching the version already used in `deep-review.yml`. The flow is fail-safe: if the webhook secret is unset or the Slack POST fails, the run is marked failed and the item is left unlabeled so a later event retries.

**Before merge effect:** the `SLACK_WEBHOOK_OSS_PRS` secret (repo or org level) needs to point at a Slack incoming webhook. Until it is set, the workflow logs a warning and no-ops, so merging now is safe.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
