### PR TITLE
test: verify built-in token can resolve collaborator permission

### DIFF
--- a/.github/workflows/test-collaborator-token-check.yml
+++ b/.github/workflows/test-collaborator-token-check.yml
@@ -1,0 +1,52 @@
+name: TEST token collaborator check
+
+# Throwaway workflow to verify the built-in GITHUB_TOKEN can resolve a user's
+# repo permission (including access granted via private teams) under the same
+# permissions the external-contributor-alerts workflow runs with.
+# Delete this file once the result is confirmed.
+
+on:
+  push:
+    branches: [test/collaborator-token-check]
+  workflow_dispatch:
+    inputs:
+      username:
+        description: "Login to check (overrides the default list)"
+        required: false
+
+# Mirror external-contributor-alerts.yml so the token is identical.
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v9
+        env:
+          TARGET_USER: ${{ inputs.username }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const input = (process.env.TARGET_USER || '').trim();
+            // teeohhem: private ClickHouse member with write access (the bug case) -> expect INTERNAL
+            // octocat:  no access -> expect EXTERNAL (control)
+            const users = input ? [input] : ['teeohhem', 'octocat'];
+            for (const username of users) {
+              try {
+                const { data, status } = await github.rest.repos.getCollaboratorPermissionLevel({
+                  owner, repo, username,
+                });
+                const verdict = data.permission !== 'none' ? 'INTERNAL' : 'EXTERNAL';
+                core.info(`[${username}] HTTP ${status} permission='${data.permission}' role='${data.role_name}' => ${verdict}`);
+              } catch (e) {
+                if (e.status === 404) {
+                  core.info(`[${username}] HTTP 404 not a collaborator => EXTERNAL`);
+                } else if (e.status === 403) {
+                  core.setFailed(`[${username}] HTTP 403 => built-in GITHUB_TOKEN CANNOT call this endpoint (would need a PAT/App token).`);
+                } else {
+                  core.setFailed(`[${username}] HTTP ${e.status}: ${e.message}`);
+                }
+              }
+            }

--- a/.github/workflows/test-collaborator-token-check.yml
+++ b/.github/workflows/test-collaborator-token-check.yml
@@ -31,15 +31,19 @@ jobs:
             const { owner, repo } = context.repo;
             const input = (process.env.TARGET_USER || '').trim();
             // teeohhem: private ClickHouse member with write access (the bug case) -> expect INTERNAL
-            // octocat:  no access -> expect EXTERNAL (control)
+            // octocat:  no granted access (public repo gives implicit read) -> expect EXTERNAL (control)
             const users = input ? [input] : ['teeohhem', 'octocat'];
+            // Public repos grant everyone implicit 'read', so test for actual
+            // granted access (triage and up), not merely permission != 'none'.
+            const isInternal = (p) => !!(p && (p.admin || p.maintain || p.push || p.triage));
             for (const username of users) {
               try {
                 const { data, status } = await github.rest.repos.getCollaboratorPermissionLevel({
                   owner, repo, username,
                 });
-                const verdict = data.permission !== 'none' ? 'INTERNAL' : 'EXTERNAL';
-                core.info(`[${username}] HTTP ${status} permission='${data.permission}' role='${data.role_name}' => ${verdict}`);
+                const perms = data.user?.permissions ?? {};
+                const verdict = isInternal(perms) ? 'INTERNAL' : 'EXTERNAL';
+                core.info(`[${username}] HTTP ${status} permission='${data.permission}' role='${data.role_name}' perms=${JSON.stringify(perms)} => ${verdict}`);
               } catch (e) {
                 if (e.status === 404) {
                   core.info(`[${username}] HTTP 404 not a collaborator => EXTERNAL`);


### PR DESCRIPTION
Throwaway test workflow to verify that the built-in Actions `GITHUB_TOKEN` can resolve a user's repository permission — including access granted through a *private* team — under the exact permission scope that `external-contributor-alerts.yml` runs with.

This validates the planned fix for the false "external" classification of private org members (see the bug where a private `MEMBER` was flagged external because `author_association` only reflects *public* membership). The workflow runs on push and checks two logins:

- `teeohhem` — a private ClickHouse member with `write` access. Expected verdict: **INTERNAL**.
- `octocat` — no access. Expected verdict: **EXTERNAL** (control).

If the restricted token returns `403`, the job fails loudly and we know a PAT/App token is required instead. This branch and file are temporary and will be deleted once the result is confirmed.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Opus_4.8_%281M%29-D97757?logo=claude&logoColor=white)
