### PR TITLE
fix(ci): skip OTel export job on fork PRs

### DIFF
--- a/.github/workflows/chart-test.yml
+++ b/.github/workflows/chart-test.yml
@@ -95,12 +95,21 @@ jobs:
           kind delete cluster --name "test-${{ matrix.suite }}" || true
 
   otel-cicd-action:
-    if: always()
+    # Only run when secrets are available. Fork PRs (external contributors) do
+    # not receive repository secrets, so OTLP_ENDPOINT is empty and the export
+    # action fails with "Name resolution failed for target dns:v1". Skip the job
+    # on fork PRs and run it for same-repo events (push, internal PRs, schedule).
+    if: ${{ always() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
     name: OpenTelemetry Export Trace
     runs-on: ubuntu-latest
     needs: [integration-test]
+    env:
+      OTLP_ENDPOINT: ${{ secrets.OTLP_ENDPOINT }}
     steps:
       - name: Export workflow
+        # Defense-in-depth: skip if the endpoint secret is unset even on
+        # same-repo runs, so an empty endpoint never reaches the action.
+        if: ${{ env.OTLP_ENDPOINT != '' }}
         uses: corentinmusard/otel-cicd-action@v4
         with:
           otlpEndpoint: ${{ secrets.OTLP_ENDPOINT }}/v1/traces


### PR DESCRIPTION
Fixes the spurious red `OpenTelemetry Export Trace` job failure that appears on every **external-contributor (fork) PR**.

## Problem

`chart-test.yml` runs on `pull_request`. GitHub withholds repository secrets from fork PRs, so `secrets.OTLP_ENDPOINT` is empty. The workflow builds the endpoint as `${{ secrets.OTLP_ENDPOINT }}/v1/traces`, which collapses to just `/v1/traces` (no host). The `corentinmusard/otel-cicd-action` then falls into its gRPC exporter branch and fails:

```
Create tracer provider for /v1/traces
Error: [{"code":14,"details":"Name resolution failed for target dns:v1","metadata":{}}]
```

Example failing run (fork PR #234, head repo `mfroembgen/ClickStack-helm-charts`):
https://github.com/ClickHouse/ClickStack-helm-charts/actions/runs/28361825424/job/84189297741

Updating the secret value does not help — no secret reaches a fork PR run.

## Fix

- **Job-level guard:** only run the export job for same-repo events (`push`, internal PRs, `schedule`, `workflow_dispatch`); skip it on fork PRs via `github.event.pull_request.head.repo.full_name == github.repository`. `always()` is preserved so failure traces still export on internal runs.
- **Defense-in-depth:** lift `OTLP_ENDPOINT` into a job `env` and gate the step on `env.OTLP_ENDPOINT != `, so an empty endpoint never reaches the action even on a same-repo run where the secret happens to be unset. (`secrets.*` is not allowed in a step-level `if`, hence the `env` indirection.)

## Impact

This job is **not a required status check**, so this change only removes the noisy ❌ on external-contributor PRs — it does not alter merge gating. Internal runs continue exporting CI traces unchanged.

## Testing

- `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses.
- Expression contexts verified manually against GitHub Actions rules (`github.*` in job `if`, `env.*` in step `if`).