### PR TITLE
[HDX] Bump clickhouse-operator to v0.0.7 + fix ClickHouse OOMKill

### DIFF
--- a/.changeset/bump-clickhouse-operator-v0.0.6.md
+++ b/.changeset/bump-clickhouse-operator-v0.0.6.md
@@ -1,5 +1,0 @@
----
-"helm-charts": patch
----
-
-chore(deps): bump clickhouse-operator-helm to v0.0.6

--- a/.changeset/bump-clickhouse-operator-v0.0.6.md
+++ b/.changeset/bump-clickhouse-operator-v0.0.6.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": patch
+---
+
+chore(deps): bump clickhouse-operator-helm to v0.0.6

--- a/.changeset/bump-clickhouse-operator-v0.0.7.md
+++ b/.changeset/bump-clickhouse-operator-v0.0.7.md
@@ -1,0 +1,11 @@
+---
+"helm-charts": patch
+---
+
+chore(deps): bump clickhouse-operator-helm to v0.0.7
+
+Also bumps the clickstack-operators chart to 1.1.0 so the updated
+dependency is published. Operator v0.0.7 no longer drops a non-empty
+Atomic `default` database during Replicated conversion
+(clickhouse-operator#255), which is why the earlier
+`enableDatabaseSync: false` workaround is not needed.

--- a/.changeset/clickhouse-explicit-resources.md
+++ b/.changeset/clickhouse-explicit-resources.md
@@ -1,0 +1,12 @@
+---
+"helm-charts": patch
+---
+
+fix(clickhouse): set explicit container resources for the ClickHouse server
+
+The clickhouse-operator applies a small default resource block (512Mi memory,
+request == limit as of operator v0.0.6) when none is provided. That is too low
+for the full ClickStack schema (many materialized views) and caused the
+ClickHouse server to OOMKill (exit 137) and crash-loop under ingestion plus
+background merges. The chart now sets explicit `containerTemplate.resources`
+(2Gi memory, 500m CPU request) which can be overridden per environment.

--- a/.changeset/clickhouse-explicit-resources.md
+++ b/.changeset/clickhouse-explicit-resources.md
@@ -2,20 +2,11 @@
 "helm-charts": patch
 ---
 
-fix(clickhouse): harden ClickHouse defaults for clickhouse-operator v0.0.6
+fix(clickhouse): set explicit container resources for the ClickHouse server
 
-Two operator-default changes in v0.0.6 broke the single-replica ClickHouse
-deployment; the chart now overrides both:
-
-- Explicit `containerTemplate.resources` (2Gi memory, 500m CPU request). The
-  operator otherwise applies a 512Mi default (request == limit as of v0.0.6),
-  which is too low for the full ClickStack schema and OOMKills the server
-  (exit 137) under ingestion plus background merges.
-
-- `settings.enableDatabaseSync: false`. The operator now defaults this to true,
-  which creates the `default` database with the Replicated (DatabaseReplicated)
-  engine so table metadata lives in Keeper. That feature targets multi-replica
-  clusters; in a single-replica deployment a transient Keeper hiccup during
-  startup desyncs the Replicated database and silently drops all seeded tables,
-  which never come back. Keeping `default` Atomic stores tables on the
-  persistent data volume so they survive restarts.
+The clickhouse-operator applies a small default resource block (512Mi memory,
+request == limit as of operator v0.0.6) when none is provided. That is too low
+for the full ClickStack schema (many materialized views) and caused the
+ClickHouse server to OOMKill (exit 137) and crash-loop under ingestion plus
+background merges. The chart now sets explicit `containerTemplate.resources`
+(2Gi memory, 500m CPU request) which can be overridden per environment.

--- a/.changeset/clickhouse-explicit-resources.md
+++ b/.changeset/clickhouse-explicit-resources.md
@@ -2,11 +2,20 @@
 "helm-charts": patch
 ---
 
-fix(clickhouse): set explicit container resources for the ClickHouse server
+fix(clickhouse): harden ClickHouse defaults for clickhouse-operator v0.0.6
 
-The clickhouse-operator applies a small default resource block (512Mi memory,
-request == limit as of operator v0.0.6) when none is provided. That is too low
-for the full ClickStack schema (many materialized views) and caused the
-ClickHouse server to OOMKill (exit 137) and crash-loop under ingestion plus
-background merges. The chart now sets explicit `containerTemplate.resources`
-(2Gi memory, 500m CPU request) which can be overridden per environment.
+Two operator-default changes in v0.0.6 broke the single-replica ClickHouse
+deployment; the chart now overrides both:
+
+- Explicit `containerTemplate.resources` (2Gi memory, 500m CPU request). The
+  operator otherwise applies a 512Mi default (request == limit as of v0.0.6),
+  which is too low for the full ClickStack schema and OOMKills the server
+  (exit 137) under ingestion plus background merges.
+
+- `settings.enableDatabaseSync: false`. The operator now defaults this to true,
+  which creates the `default` database with the Replicated (DatabaseReplicated)
+  engine so table metadata lives in Keeper. That feature targets multi-replica
+  clusters; in a single-replica deployment a transient Keeper hiccup during
+  startup desyncs the Replicated database and silently drops all seeded tables,
+  which never come back. Keeping `default` Atomic stores tables on the
+  persistent data volume so they survive restarts.

--- a/charts/clickstack-operators/Chart.lock
+++ b/charts/clickstack-operators/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.7.0
 - name: clickhouse-operator-helm
   repository: oci://ghcr.io/clickhouse
-  version: 0.0.2
-digest: sha256:1daf572004da83b1836c8867f11198530652fee6905d4786a2d5eef87bc611cd
-generated: "2026-03-04T16:52:51.068188-06:00"
+  version: 0.0.6
+digest: sha256:5afcb0d78e0ceecf1a18f3f7dfb52ee2627b7acea2621ffa411ee7bfb530adf7
+generated: "2026-06-19T17:41:30.214406+02:00"

--- a/charts/clickstack-operators/Chart.lock
+++ b/charts/clickstack-operators/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 1.7.0
 - name: clickhouse-operator-helm
   repository: oci://ghcr.io/clickhouse
-  version: 0.0.6
-digest: sha256:5afcb0d78e0ceecf1a18f3f7dfb52ee2627b7acea2621ffa411ee7bfb530adf7
-generated: "2026-06-19T17:41:30.214406+02:00"
+  version: 0.0.7
+digest: sha256:aca8ccb62c3bec324b48f176bb2b60ea08c79c22bffbd8ef720f639d564572b1
+generated: "2026-07-20T11:15:15.487301-07:00"

--- a/charts/clickstack-operators/Chart.yaml
+++ b/charts/clickstack-operators/Chart.yaml
@@ -13,6 +13,6 @@ dependencies:
     repository: https://mongodb.github.io/helm-charts
     alias: mongodb-operator
   - name: clickhouse-operator-helm
-    version: "~0.0.2"
+    version: "~0.0.6"
     repository: oci://ghcr.io/clickhouse
     alias: clickhouse-operator

--- a/charts/clickstack-operators/Chart.yaml
+++ b/charts/clickstack-operators/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   installing clickstack/clickstack to ensure CRDs are registered.
 home: https://clickhouse.com/docs/use-cases/observability/clickstack
 type: application
-version: 1.0.0
+version: 1.1.0
 appVersion: "1.0.0"
 dependencies:
   - name: mongodb-kubernetes
@@ -13,6 +13,6 @@ dependencies:
     repository: https://mongodb.github.io/helm-charts
     alias: mongodb-operator
   - name: clickhouse-operator-helm
-    version: "~0.0.6"
+    version: "~0.0.7"
     repository: oci://ghcr.io/clickhouse
     alias: clickhouse-operator

--- a/charts/clickstack-operators/values.yaml
+++ b/charts/clickstack-operators/values.yaml
@@ -9,8 +9,8 @@ mongodb-operator:
 # See https://clickhouse.com/docs/clickhouse-operator/overview for all options
 clickhouse-operator:
   webhook:
-    enable: false
+    enabled: false
   certManager:
-    enable: false
+    enabled: false
   crd:
-    enable: true
+    enabled: true

--- a/charts/clickstack/tests/clickhouse-deployment_test.yaml
+++ b/charts/clickstack/tests/clickhouse-deployment_test.yaml
@@ -166,11 +166,3 @@ tests:
           path: spec.settings.extraUsersConfig.users.app
       - isNotNull:
           path: spec.settings.extraUsersConfig.users.otelcollector
-
-  - it: should disable operator databaseSync so the default DB stays Atomic
-    templates:
-      - clickhouse/cluster.yaml
-    asserts:
-      - equal:
-          path: spec.settings.enableDatabaseSync
-          value: false

--- a/charts/clickstack/tests/clickhouse-deployment_test.yaml
+++ b/charts/clickstack/tests/clickhouse-deployment_test.yaml
@@ -68,6 +68,20 @@ tests:
           path: spec.dataVolumeClaimSpec.resources.requests.storage
           value: 10Gi
 
+  - it: should set explicit container resources so the operator default does not OOMKill ClickHouse
+    templates:
+      - clickhouse/cluster.yaml
+    asserts:
+      - equal:
+          path: spec.containerTemplate.resources.requests.memory
+          value: 2Gi
+      - equal:
+          path: spec.containerTemplate.resources.limits.memory
+          value: 2Gi
+      - equal:
+          path: spec.containerTemplate.resources.requests.cpu
+          value: 500m
+
   - it: should resolve keeperClusterRef template expression
     templates:
       - clickhouse/cluster.yaml

--- a/charts/clickstack/tests/clickhouse-deployment_test.yaml
+++ b/charts/clickstack/tests/clickhouse-deployment_test.yaml
@@ -166,3 +166,11 @@ tests:
           path: spec.settings.extraUsersConfig.users.app
       - isNotNull:
           path: spec.settings.extraUsersConfig.users.otelcollector
+
+  - it: should disable operator databaseSync so the default DB stays Atomic
+    templates:
+      - clickhouse/cluster.yaml
+    asserts:
+      - equal:
+          path: spec.settings.enableDatabaseSync
+          value: false

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -345,9 +345,6 @@ clickhouse:
           requests:
             storage: 10Gi
       settings:
-        # Keep the `default` database Atomic; the Replicated engine the operator
-        # selects when this is true drops seeded tables on Keeper desync.
-        enableDatabaseSync: false
         extraUsersConfig:
           users:
             app:

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -328,6 +328,17 @@ clickhouse:
         image:
           repository: clickhouse/clickhouse-server
           tag: "25.7-alpine"
+        # Explicit resources for the ClickHouse server container. Without this
+        # the clickhouse-operator applies its own small default (512Mi memory,
+        # with request == limit as of operator v0.0.6), which is too low for the
+        # full ClickStack schema (many materialized views) and causes the server
+        # to OOMKill under ingestion + background merges. Override per environment.
+        resources:
+          requests:
+            cpu: 500m
+            memory: 2Gi
+          limits:
+            memory: 2Gi
       replicas: 1
       shards: 1
       keeperClusterRef:

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -328,11 +328,6 @@ clickhouse:
         image:
           repository: clickhouse/clickhouse-server
           tag: "25.7-alpine"
-        # Explicit resources for the ClickHouse server container. Without this
-        # the clickhouse-operator applies its own small default (512Mi memory,
-        # with request == limit as of operator v0.0.6), which is too low for the
-        # full ClickStack schema (many materialized views) and causes the server
-        # to OOMKill under ingestion + background merges. Override per environment.
         resources:
           requests:
             cpu: 500m
@@ -350,15 +345,8 @@ clickhouse:
           requests:
             storage: 10Gi
       settings:
-        # Disable the operator's database-sync feature (clickhouse-operator
-        # v0.0.6 defaults enableDatabaseSync: true). When enabled, the operator
-        # creates the `default` database with the Replicated (DatabaseReplicated)
-        # engine so table metadata lives in Keeper. That feature targets
-        # multi-replica clusters; in this single-replica deployment it only adds
-        # fragility -- a transient Keeper hiccup during startup desyncs the
-        # Replicated database and silently drops all seeded tables, which never
-        # come back. Keeping the `default` database Atomic stores tables on the
-        # persistent data volume so they survive restarts.
+        # Keep the `default` database Atomic; the Replicated engine the operator
+        # selects when this is true drops seeded tables on Keeper desync.
         enableDatabaseSync: false
         extraUsersConfig:
           users:

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -350,6 +350,16 @@ clickhouse:
           requests:
             storage: 10Gi
       settings:
+        # Disable the operator's database-sync feature (clickhouse-operator
+        # v0.0.6 defaults enableDatabaseSync: true). When enabled, the operator
+        # creates the `default` database with the Replicated (DatabaseReplicated)
+        # engine so table metadata lives in Keeper. That feature targets
+        # multi-replica clusters; in this single-replica deployment it only adds
+        # fragility -- a transient Keeper hiccup during startup desyncs the
+        # Replicated database and silently drops all seeded tables, which never
+        # come back. Keeping the `default` database Atomic stores tables on the
+        # persistent data volume so they survive restarts.
+        enableDatabaseSync: false
         extraUsersConfig:
           users:
             app:

--- a/integration-tests/full-stack/assert.sh
+++ b/integration-tests/full-stack/assert.sh
@@ -12,7 +12,7 @@ echo "Waiting for services to initialize..."
 sleep 30
 
 echo "Waiting for all pods to be ready..."
-kubectl wait --for=condition=Ready pods --all --timeout=600s || true
+kubectl wait --for=condition=Ready pods --all --field-selector=status.phase!=Succeeded --timeout=600s || true
 
 echo "Pod status:"
 kubectl get pods -o wide
@@ -24,7 +24,7 @@ echo "Checking ClickHouseCluster CR..."
 kubectl get clickhousecluster -o wide || true
 
 echo "Waiting for all pods to be ready (final check)..."
-kubectl wait --for=condition=Ready pods --all --timeout=600s
+kubectl wait --for=condition=Ready pods --all --field-selector=status.phase!=Succeeded --timeout=600s
 
 echo "Final pod status:"
 kubectl get pods -o wide


### PR DESCRIPTION
## Summary

Bumps `clickhouse-operator-helm` from v0.0.2 to **v0.0.7** and fixes a resulting full-stack integration-test failure caused by a new operator resource default that OOMKilled the single-replica ClickHouse deployment.

Supersedes the upstream bump in [ClickHouse/ClickStack-helm-charts#224](https://github.com/ClickHouse/ClickStack-helm-charts/pull/224).

## Changes

### Operator bump
- `clickhouse-operator-helm` `~0.0.2` → `~0.0.7` (`Chart.yaml`, `Chart.lock`)
- `clickstack-operators` chart `1.0.0` → **`1.1.0`** — required so chart-releaser (`skip_existing: true`) actually publishes the updated dependency; minor (not patch) because operator behavior changed and values keys were renamed since 1.0.0.
- `values.yaml`: rename `enable` → `enabled` for `webhook` / `certManager` / `crd` — **required**, since v0.0.6+ renamed these keys. The old `enable` keys are silently ignored and would leave `webhook`/`certManager` enabled, breaking the install (no cert-manager present).
- `integration-tests/full-stack/assert.sh`: scope `kubectl wait` with `--field-selector=status.phase!=Succeeded`. **Required by the bump:** v0.0.4+ introduces a version-probe Job (absent in v0.0.2) that leaves a `Completed` pod, which `kubectl wait --for=condition=Ready pods --all` can never satisfy → wait times out → suite fails.

### ClickHouse hardening (new)

**Explicit container resources (`containerTemplate.resources`: 2Gi memory, 500m CPU request)**

The chart previously set no `resources`, relying on the operator default. v0.0.6 changed that default (operator [PR #206](https://github.com/ClickHouse/clickhouse-operator/pull/206): *"use the same req/limit for memory in default"*) to **512Mi, request == limit**. At 512Mi, ClickHouse computes `max_server_memory_usage` ≈ 460 MiB; the full ClickStack schema plus ingestion and background merges exceeds it → **OOMKilled (exit 137)**, crash-loop. The chart now sets explicit resources, overridable per environment via `clickhouse.cluster.spec`.

### Why v0.0.7 (and not v0.0.6)

v0.0.6 defaults `enableDatabaseSync: true`, converting the `default` database to the **Replicated (DatabaseReplicated)** engine. In this single-replica deployment, a transient Keeper exception during ClickHouse startup (`Cannot use any of provided ZooKeeper nodes`, exit 231) desynced the Replicated database and **silently dropped every seeded table** (`otel_traces`, `otel_logs`, …) — the collector then loops on `Table default.otel_traces does not exist` and the smoke test times out.

This branch initially carried an `enableDatabaseSync: false` workaround for that. Operator **v0.0.7** fixes the root cause upstream ([clickhouse-operator#255](https://github.com/ClickHouse/clickhouse-operator/pull/255): *don't drop a non-empty Atomic default database during Replicated conversion*), so the workaround was reverted and we ship v0.0.7 with operator defaults. The upstream chart values are byte-identical between 0.0.6 and 0.0.7, so no further values changes were needed.

## Verification

- **Resources (local kind, fresh full-stack cluster):** repro'd ClickHouse OOMKill at 512Mi; after fix CH sees 2.0 GiB, `max_server_memory_usage` 1.80 GiB, stable.
- **databaseSync (on v0.0.6):** repro'd — `default` engine `Replicated`, all tables dropped after a startup Keeper hiccup. v0.0.7 carries the upstream fix; CI full-stack suite exercises it end-to-end.
- `helm unittest charts/clickstack`: **179/179 pass**.
- Both charts and both example values files (`alb-ingress`, `api-only`) render cleanly.

## Note

2Gi raises the chart's baseline ClickHouse memory footprint vs. the operator's 512Mi default. Overridable per environment via `clickhouse.cluster.spec`.

## Ref
https://github.com/ClickHouse/ClickStack-helm-charts/pull/224
https://github.com/ClickHouse/ClickStack-helm-charts/pull/226
https://github.com/ClickHouse/clickhouse-operator/releases/tag/v0.0.7
