### PR TITLE
feat(clickstack): surface ClickHouse table TTL as configurable values

### DIFF
--- a/.changeset/expose-table-ttl.md
+++ b/.changeset/expose-table-ttl.md
@@ -1,0 +1,7 @@
+---
+"helm-charts": minor
+---
+
+feat(clickstack): surface ClickHouse table TTL as configurable values
+
+Defaults and documents `HYPERDX_OTEL_EXPORTER_TABLES_TTL` (720h) in `hyperdx.config`, and documents the per-signal overrides (`HYPERDX_OTEL_EXPORTER_LOGS_TTL` / `_TRACES_TTL` / `_METRICS_TTL` / `_SESSIONS_TTL`) plus `HYPERDX_OTEL_EXPORTER_RECONCILE_TABLE_TTL`. Operators can now set ClickHouse data retention per signal — e.g. keep logs and traces for 6 months for compliance while metrics stay short — without hand-crafting collector env vars. The per-signal overrides and reconcile need collector image 2.36.0 or newer, which is the chart's current default.

--- a/charts/clickstack/tests/app-configmap_test.yaml
+++ b/charts/clickstack/tests/app-configmap_test.yaml
@@ -57,3 +57,23 @@ tests:
       - matchRegex:
           path: data.OTEL_EXPORTER_OTLP_ENDPOINT
           pattern: "http://.*-otel-collector:4318"
+
+  - it: should render the default ClickHouse table TTL
+    asserts:
+      - equal:
+          path: data.HYPERDX_OTEL_EXPORTER_TABLES_TTL
+          value: "720h"
+
+  - it: should render per-signal TTL and reconcile overrides from config
+    set:
+      hyperdx:
+        config:
+          HYPERDX_OTEL_EXPORTER_LOGS_TTL: "180d"
+          HYPERDX_OTEL_EXPORTER_RECONCILE_TABLE_TTL: "true"
+    asserts:
+      - equal:
+          path: data.HYPERDX_OTEL_EXPORTER_LOGS_TTL
+          value: "180d"
+      - equal:
+          path: data.HYPERDX_OTEL_EXPORTER_RECONCILE_TABLE_TTL
+          value: "true"

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -61,6 +61,18 @@ hyperdx:
     HYPERDX_OTEL_EXPORTER_CLICKHOUSE_DATABASE: "default"
     CLICKHOUSE_USER: "otelcollector"
     RUN_SCHEDULED_TASKS_EXTERNALLY: "false"
+    # ClickHouse table retention (TTL). Go-duration string; "d" suffix allowed (e.g. "180d").
+    # This global default applies to every signal.
+    HYPERDX_OTEL_EXPORTER_TABLES_TTL: "720h"
+    # Per-signal overrides (each falls back to HYPERDX_OTEL_EXPORTER_TABLES_TTL when unset),
+    # e.g. keep logs & traces longer for compliance while metrics stay short:
+    #   HYPERDX_OTEL_EXPORTER_LOGS_TTL: "180d"
+    #   HYPERDX_OTEL_EXPORTER_TRACES_TTL: "180d"
+    #   HYPERDX_OTEL_EXPORTER_METRICS_TTL: "30d"
+    #   HYPERDX_OTEL_EXPORTER_SESSIONS_TTL: "30d"
+    # Apply TTL changes to tables that already exist, not just newly created ones (default false):
+    #   HYPERDX_OTEL_EXPORTER_RECONCILE_TABLE_TTL: "true"
+    # Per-signal TTLs and reconcile need collector image 2.36.0 or newer.
     # Service endpoint defaults -- override to use external instances
     FRONTEND_URL: "http://localhost:3000"
     MONGO_URI: 'mongodb://hyperdx:{{ .Values.hyperdx.secrets.MONGODB_PASSWORD }}@{{ include "clickstack.mongodb.svc" . }}:27017/hyperdx?authSource=hyperdx'


### PR DESCRIPTION
## What

Surfaces ClickHouse table retention (TTL) as documented, configurable values in the `clickstack` chart:

- Defaults `HYPERDX_OTEL_EXPORTER_TABLES_TTL` (`720h`) in `hyperdx.config` so the global retention knob is discoverable and tunable in `values.yaml`.
- Documents the per-signal overrides — `HYPERDX_OTEL_EXPORTER_LOGS_TTL` / `_TRACES_TTL` / `_METRICS_TTL` / `_SESSIONS_TTL` — and `HYPERDX_OTEL_EXPORTER_RECONCILE_TABLE_TTL`, inline where the rest of the collector env lives.

## Why

Data retention is usually a compliance requirement (SOC 2, ISO 27001, HIPAA, PCI-DSS): security-relevant **logs** — and often **traces** — must be kept for 6–12 months, while high-volume **metrics** stay short to control storage cost. That's a *per-signal* retention policy. Today an operator has to know the exact collector env-var names and hand-inject them; this makes the retention controls first-class and self-documenting.

The collector-side capability shipped in `@hyperdx/otel-collector@2.36.0` (hyperdxio/hyperdx#2709, implementing hyperdxio/hyperdx#1311). Since this chart already defaults to collector image `2.36.0`, the per-signal overrides and reconcile work out of the box — this PR just makes them visible.

## Changes

- `charts/clickstack/values.yaml` — add `HYPERDX_OTEL_EXPORTER_TABLES_TTL: "720h"` to `hyperdx.config`, with a documented block for the per-signal overrides + reconcile flag.
- `charts/clickstack/tests/app-configmap_test.yaml` — assert the default TTL renders and that per-signal / reconcile overrides pass through.
- Changeset (`helm-charts`, minor).

## Compatibility

- **No default behavior change:** the global TTL default (`720h`) matches the collector's own default, and the per-signal keys are left commented out, so nothing changes unless an operator opts in.
- Per-signal overrides and reconcile need collector image **2.36.0 or newer** (the chart's current default); the note in `values.yaml` says so for anyone pinning an older tag.
- `HYPERDX_OTEL_EXPORTER_TABLES_TTL` itself has worked since hyperdxio/hyperdx#1720 — this only surfaces it.

## Testing

- `helm lint charts/clickstack` — clean.
- `helm template` — renders `HYPERDX_OTEL_EXPORTER_TABLES_TTL: "720h"` in `clickstack-config`.
- `helm unittest charts/clickstack` — **195/195 pass** (incl. 2 new config assertions).
