### PR TITLE
feat: support explicit HyperDX Deployment and pod annotations

### DIFF
--- a/.changeset/expose-hyperdx-deployment-annotations.md
+++ b/.changeset/expose-hyperdx-deployment-annotations.md
@@ -2,4 +2,4 @@
 "helm-charts": minor
 ---
 
-Add explicit `hyperdx.deployment.deploymentAnnotations` and `hyperdx.deployment.podAnnotations` values while preserving `hyperdx.deployment.annotations` as a deprecated pod annotation alias.
+Add explicit `hyperdx.deployment.deploymentAnnotations` and `hyperdx.deployment.podAnnotations` values while preserving `hyperdx.deployment.annotations` as a deprecated pod annotation alias. When both pod annotation values contain the same key, `podAnnotations` takes precedence.

--- a/.changeset/expose-hyperdx-deployment-annotations.md
+++ b/.changeset/expose-hyperdx-deployment-annotations.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": minor
+---
+
+Add `hyperdx.deployment.deploymentAnnotations` for setting annotations on the HyperDX Deployment metadata while preserving `hyperdx.deployment.annotations` for pod annotations.

--- a/.changeset/expose-hyperdx-deployment-annotations.md
+++ b/.changeset/expose-hyperdx-deployment-annotations.md
@@ -2,4 +2,4 @@
 "helm-charts": minor
 ---
 
-Add `hyperdx.deployment.deploymentAnnotations` for setting annotations on the HyperDX Deployment metadata while preserving `hyperdx.deployment.annotations` for pod annotations.
+Add explicit `hyperdx.deployment.deploymentAnnotations` and `hyperdx.deployment.podAnnotations` values while preserving `hyperdx.deployment.annotations` as a deprecated pod annotation alias.

--- a/charts/clickstack/templates/hyperdx/deployment.yaml
+++ b/charts/clickstack/templates/hyperdx/deployment.yaml
@@ -31,7 +31,7 @@ spec:
       annotations:
       {{- if $podAnnotations }}
         {{- with $podAnnotations }}
-        {{- toYaml . | nindent 8 }} 
+        {{- toYaml . | nindent 8 }}
         {{- end -}}
       {{- end }}
     spec:

--- a/charts/clickstack/templates/hyperdx/deployment.yaml
+++ b/charts/clickstack/templates/hyperdx/deployment.yaml
@@ -2,6 +2,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "clickstack.hyperdx.fullname" . }}
+  {{- with .Values.hyperdx.deployment.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   labels:
     {{- include "clickstack.labels" . | nindent 4 }}
     app: {{ include "clickstack.fullname" . }}

--- a/charts/clickstack/templates/hyperdx/deployment.yaml
+++ b/charts/clickstack/templates/hyperdx/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $podAnnotations := mergeOverwrite (dict) (default (dict) .Values.hyperdx.deployment.annotations) (default (dict) .Values.hyperdx.deployment.podAnnotations) -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -28,8 +29,8 @@ spec:
         {{- include "clickstack.selectorLabels" . | nindent 8 }}
         app: {{ include "clickstack.fullname" . }}
       annotations:
-      {{- if .Values.hyperdx.deployment.annotations }}
-        {{- with .Values.hyperdx.deployment.annotations }}
+      {{- if $podAnnotations }}
+        {{- with $podAnnotations }}
         {{- toYaml . | nindent 8 }} 
         {{- end -}}
       {{- end }}

--- a/charts/clickstack/tests/hyperdx-deployment_test.yaml
+++ b/charts/clickstack/tests/hyperdx-deployment_test.yaml
@@ -6,6 +6,8 @@ tests:
     asserts:
       - isKind:
           of: Deployment
+      - isNull:
+          path: metadata.annotations
       - equal:
           path: spec.replicas
           value: 1
@@ -42,7 +44,7 @@ tests:
           path: spec.replicas
           value: 3
 
-  - it: should add custom annotations when provided
+  - it: should add custom pod annotations when provided
     set:
       hyperdx:
         deployment:
@@ -55,6 +57,24 @@ tests:
           content:
             prometheus.io/scrape: "true"
             prometheus.io/port: "3000"
+
+  - it: should keep deployment and pod annotations separate
+    set:
+      hyperdx:
+        deployment:
+          deploymentAnnotations:
+            example.com/configuration: deployment
+          annotations:
+            example.com/configuration: pod
+    asserts:
+      - isSubset:
+          path: metadata.annotations
+          content:
+            example.com/configuration: deployment
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            example.com/configuration: pod
             
   - it: should add custom labels when provided
     set:

--- a/charts/clickstack/tests/hyperdx-deployment_test.yaml
+++ b/charts/clickstack/tests/hyperdx-deployment_test.yaml
@@ -44,7 +44,7 @@ tests:
           path: spec.replicas
           value: 3
 
-  - it: should add custom pod annotations when provided
+  - it: should preserve the deprecated annotations alias for pod annotations
     set:
       hyperdx:
         deployment:
@@ -58,13 +58,25 @@ tests:
             prometheus.io/scrape: "true"
             prometheus.io/port: "3000"
 
+  - it: should add custom pod annotations when podAnnotations is provided
+    set:
+      hyperdx:
+        deployment:
+          podAnnotations:
+            example.com/pod: "enabled"
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            example.com/pod: "enabled"
+
   - it: should keep deployment and pod annotations separate
     set:
       hyperdx:
         deployment:
           deploymentAnnotations:
             example.com/configuration: deployment
-          annotations:
+          podAnnotations:
             example.com/configuration: pod
     asserts:
       - isSubset:
@@ -75,6 +87,22 @@ tests:
           path: spec.template.metadata.annotations
           content:
             example.com/configuration: pod
+
+  - it: should prefer podAnnotations over the deprecated annotations alias
+    set:
+      hyperdx:
+        deployment:
+          annotations:
+            example.com/configuration: legacy
+            example.com/legacy: preserved
+          podAnnotations:
+            example.com/configuration: explicit
+    asserts:
+      - isSubset:
+          path: spec.template.metadata.annotations
+          content:
+            example.com/configuration: explicit
+            example.com/legacy: preserved
             
   - it: should add custom labels when provided
     set:

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -110,6 +110,8 @@ hyperdx:
     # Annotations applied to the HyperDX Deployment metadata.
     deploymentAnnotations: {}
     # Annotations applied to the HyperDX pod template metadata.
+    podAnnotations: {}
+    # Deprecated: use podAnnotations. Retained for backward compatibility.
     annotations: {}
     labels: {}
     env: []

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -111,7 +111,8 @@ hyperdx:
     deploymentAnnotations: {}
     # Annotations applied to the HyperDX pod template metadata.
     podAnnotations: {}
-    # Deprecated: use podAnnotations. Retained for backward compatibility.
+    # Deprecated: use podAnnotations. Retained for backward compatibility;
+    # podAnnotations takes precedence when both maps contain the same key.
     annotations: {}
     labels: {}
     env: []

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -107,6 +107,9 @@ hyperdx:
     tolerations: []
     topologySpreadConstraints: []
     priorityClassName: ""
+    # Annotations applied to the HyperDX Deployment metadata.
+    deploymentAnnotations: {}
+    # Annotations applied to the HyperDX pod template metadata.
     annotations: {}
     labels: {}
     env: []


### PR DESCRIPTION
## Summary

- add `hyperdx.deployment.deploymentAnnotations` for HyperDX Deployment metadata
- add `hyperdx.deployment.podAnnotations` for HyperDX pod-template metadata
- retain `hyperdx.deployment.annotations` as a deprecated compatibility alias
- document and test that `podAnnotations` wins on duplicate legacy keys

## Motivation

The existing `hyperdx.deployment.annotations` value configures `spec.template.metadata.annotations`, but its scope is ambiguous and there is no value for the Deployment object's `metadata.annotations`. Explicit names make both Kubernetes metadata surfaces clear without breaking existing installations.

## Backward compatibility

The new values default to empty maps. Existing `hyperdx.deployment.annotations` values continue to render on the pod template. When both `annotations` and `podAnnotations` contain the same key, the explicit `podAnnotations` value takes precedence; non-conflicting legacy annotations are preserved.

## Test plan

- [x] `helm unittest charts/clickstack` — 28 suites, 190 tests pass
- [x] focused HyperDX suite — 33 tests pass
- [x] `helm lint charts/clickstack`
- [x] default values and all three example values files render with Helm 3.12.0
- [x] focused render confirms distinct Deployment and pod annotations plus compatibility merge precedence
- [x] `git diff --check`

Fixes #254.
