### PR TITLE
feat: add HyperDX security contexts

### DIFF
--- a/.changeset/add-hyperdx-security-contexts.md
+++ b/.changeset/add-hyperdx-security-contexts.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": minor
+---
+
+Add optional pod and container security contexts for the HyperDX Deployment, wait-for-mongodb init container, and check-alerts CronJob.

--- a/charts/clickstack/templates/hyperdx/cronjob-check-alerts.yaml
+++ b/charts/clickstack/templates/hyperdx/cronjob-check-alerts.yaml
@@ -21,11 +21,19 @@ spec:
           imagePullSecrets:
             {{- toYaml .Values.global.imagePullSecrets | nindent 12 }}
           {{- end }}
+          {{- with .Values.hyperdx.deployment.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           restartPolicy: OnFailure
           containers:
             - name: task
               image: "{{ .Values.hyperdx.deployment.image.repository }}:{{ .Values.hyperdx.deployment.image.tag | default .Chart.AppVersion }}"
               imagePullPolicy: {{ .Values.hyperdx.deployment.image.pullPolicy }}
+              {{- with .Values.hyperdx.deployment.containerSecurityContext }}
+              securityContext:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
               {{- $tag := .Values.hyperdx.deployment.image.tag | default .Chart.AppVersion -}}
               {{- if and (regexMatch "^[0-9]+\\.[0-9]+\\.[0-9]+" $tag) (semverCompare "< 2.7.0" $tag) }} # before esbuild revert
               command:

--- a/charts/clickstack/templates/hyperdx/deployment.yaml
+++ b/charts/clickstack/templates/hyperdx/deployment.yaml
@@ -53,6 +53,10 @@ spec:
       {{- if or .Values.hyperdx.serviceAccount.create .Values.hyperdx.serviceAccount.name }}
       serviceAccountName: {{ .Values.hyperdx.serviceAccount.name | default (include "clickstack.hyperdx.fullname" .) }}
       {{- end }}
+      {{- with .Values.hyperdx.deployment.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- if .Values.global.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml .Values.global.imagePullSecrets | nindent 8 }}
@@ -63,6 +67,10 @@ spec:
         - name: wait-for-mongodb
           image: {{ .Values.hyperdx.deployment.waitForMongodb.image }}
           imagePullPolicy: {{ .Values.hyperdx.deployment.waitForMongodb.pullPolicy }}
+          {{- with .Values.hyperdx.deployment.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           command: ['sh', '-c', 'until nc -z {{ include "clickstack.mongodb.svc" . }} 27017; do echo waiting for mongodb; sleep 2; done;']
         {{- end }}
         {{- with .Values.hyperdx.deployment.initContainers }}
@@ -77,6 +85,10 @@ spec:
         - name: app
           image: "{{ .Values.hyperdx.deployment.image.repository }}:{{ .Values.hyperdx.deployment.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.hyperdx.deployment.image.pullPolicy }}
+          {{- with .Values.hyperdx.deployment.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           ports:
             - name: app-port
               containerPort: {{ .Values.hyperdx.ports.app }}

--- a/charts/clickstack/tests/hyperdx-deployment_test.yaml
+++ b/charts/clickstack/tests/hyperdx-deployment_test.yaml
@@ -33,6 +33,12 @@ tests:
           content:
             secretRef:
               name: clickstack-secret
+      - isNull:
+          path: spec.template.spec.securityContext
+      - isNull:
+          path: spec.template.spec.initContainers[0].securityContext
+      - isNull:
+          path: spec.template.spec.containers[0].securityContext
 
   - it: should set custom replicas when provided
     set:
@@ -43,6 +49,41 @@ tests:
       - equal:
           path: spec.replicas
           value: 3
+
+  - it: should configure pod and managed container security contexts
+    set:
+      hyperdx:
+        deployment:
+          podSecurityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containerSecurityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext
+          value:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+      - equal:
+          path: spec.template.spec.initContainers[0].securityContext
+          value:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+      - equal:
+          path: spec.template.spec.containers[0].securityContext
+          value:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
 
   - it: should preserve the deprecated annotations alias for pod annotations
     set:

--- a/charts/clickstack/tests/task-checkAlerts_test.yaml
+++ b/charts/clickstack/tests/task-checkAlerts_test.yaml
@@ -65,6 +65,40 @@ tests:
           content:
             name: OTEL_SERVICE_NAME
             value: "hdx-oss-task-check-alerts"
+      - isNull:
+          path: spec.jobTemplate.spec.template.spec.securityContext
+      - isNull:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext
+
+  - it: should configure pod and container security contexts
+    set:
+      hyperdx:
+        deployment:
+          podSecurityContext:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          containerSecurityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+        tasks:
+          enabled: true
+    asserts:
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.securityContext
+          value:
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+      - equal:
+          path: spec.jobTemplate.spec.template.spec.containers[0].securityContext
+          value:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
 
   - it: should use default schedule when not provided
     set:

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -123,6 +123,10 @@ hyperdx:
     volumes: []
     # Additional volume mounts to apply to the HyperDX container.
     volumeMounts: []
+    # Pod-level security context for HyperDX workloads.
+    podSecurityContext: {}
+    # Container-level security context for managed HyperDX containers.
+    containerSecurityContext: {}
     waitForMongodb:
       image: "busybox@sha256:1fcf5df59121b92d61e066df1788e8df0cc35623f5d62d9679a41e163b6a0cdb"
       pullPolicy: IfNotPresent


### PR DESCRIPTION
## Summary

- add optional `hyperdx.deployment.podSecurityContext` to the HyperDX Deployment and check-alerts CronJob pod specs
- add optional `hyperdx.deployment.containerSecurityContext` to the app, wait-for-mongodb, and check-alerts task containers
- keep both defaults as empty maps so existing rendered manifests remain unchanged

## Motivation

Clusters enforcing the Kubernetes Restricted Pod Security Standard need controls such as non-root execution, seccomp profiles, disabled privilege escalation, and dropped capabilities. These passthrough values let operators satisfy their policy without coupling the chart to a specific platform or changing its defaults.

## Backward compatibility

Both values default to `{}` and are rendered through guarded `with` blocks. Default and task-enabled output is byte-identical when the values are unset.

## Test plan

- [x] `helm unittest charts/clickstack` (28 suites, 192 tests)
- [x] focused Deployment and check-alerts suites
- [x] `helm lint --strict charts/clickstack`
- [x] default and example values render successfully
- [x] packaged chart renders successfully
- [x] restricted contexts render on the Deployment pod, app and wait init containers, CronJob pod, and task container