### PR TITLE
feat: point readiness probe at Mongo-aware /ready endpoint

### DIFF
--- a/.changeset/mongo-aware-readiness-probe.md
+++ b/.changeset/mongo-aware-readiness-probe.md
@@ -1,0 +1,9 @@
+---
+"helm-charts": minor
+---
+
+Point the HyperDX readiness probe at the new Mongo-aware `/ready` endpoint and make both probe paths configurable.
+
+`/ready` (added in HyperDX 2.36.0, see hyperdxio/hyperdx#2968) returns 503 until the API's MongoDB connection is established, so pods that cannot serve Mongo-backed requests are removed from Service endpoints instead of staying Ready indefinitely (hyperdxio/hyperdx#2966). The liveness probe stays on `/health`, which remains a pure process-liveness check.
+
+New values: `hyperdx.deployment.livenessProbe.path` (default `/health`) and `hyperdx.deployment.readinessProbe.path` (default `/ready`). If you pin `hyperdx.deployment.image.tag` to a version older than 2.36.0, set `readinessProbe.path: /health` — those images do not serve `/ready`.

--- a/charts/clickstack/templates/hyperdx/deployment.yaml
+++ b/charts/clickstack/templates/hyperdx/deployment.yaml
@@ -103,7 +103,7 @@ spec:
           {{- if .Values.hyperdx.deployment.livenessProbe.enabled }}
           livenessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.hyperdx.deployment.livenessProbe.path | default "/health" }}
               port: {{ .Values.hyperdx.ports.api }}
             initialDelaySeconds: {{ .Values.hyperdx.deployment.livenessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.hyperdx.deployment.livenessProbe.periodSeconds }}
@@ -113,7 +113,7 @@ spec:
           {{- if .Values.hyperdx.deployment.readinessProbe.enabled }}
           readinessProbe:
             httpGet:
-              path: /health
+              path: {{ .Values.hyperdx.deployment.readinessProbe.path | default "/ready" }}
               port: {{ .Values.hyperdx.ports.api }}
             initialDelaySeconds: {{ .Values.hyperdx.deployment.readinessProbe.initialDelaySeconds }}
             periodSeconds: {{ .Values.hyperdx.deployment.readinessProbe.periodSeconds }}

--- a/charts/clickstack/tests/hyperdx-deployment_test.yaml
+++ b/charts/clickstack/tests/hyperdx-deployment_test.yaml
@@ -388,7 +388,7 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe
           content:
             httpGet:
-              path: /health
+              path: /ready
               port: 8000
             initialDelaySeconds: 1
             periodSeconds: 10
@@ -452,12 +452,31 @@ tests:
           path: spec.template.spec.containers[0].readinessProbe
           content:
             httpGet:
-              path: /health
+              path: /ready
               port: 8000
             initialDelaySeconds: 5
             periodSeconds: 20
             timeoutSeconds: 3
             failureThreshold: 2
+
+  - it: should use custom probe paths when provided
+    set:
+      hyperdx:
+        deployment:
+          livenessProbe:
+            enabled: true
+            path: /livez
+          readinessProbe:
+            # e.g. image tags < 2.36.0 that predate the /ready endpoint
+            enabled: true
+            path: /health
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.httpGet.path
+          value: /livez
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: /health
 
   - it: should use custom apiPort in probes when provided
     set:

--- a/charts/clickstack/tests/hyperdx-deployment_test.yaml
+++ b/charts/clickstack/tests/hyperdx-deployment_test.yaml
@@ -467,7 +467,6 @@ tests:
             enabled: true
             path: /livez
           readinessProbe:
-            # e.g. image tags < 2.36.0 that predate the /ready endpoint
             enabled: true
             path: /health
     asserts:

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -93,12 +93,21 @@ hyperdx:
     resources: {}
     livenessProbe:
       enabled: true
+      # Liveness only checks the process is serving HTTP — it deliberately
+      # checks no external dependencies, since restarting the pod does not
+      # fix a dependency outage.
+      path: /health
       initialDelaySeconds: 10
       periodSeconds: 30
       timeoutSeconds: 5
       failureThreshold: 3
     readinessProbe:
       enabled: true
+      # Mongo-aware readiness: /ready returns 503 until the API's MongoDB
+      # connection is established, so unready pods are removed from Service
+      # endpoints. Requires HyperDX >= 2.36.0 — set to /health when pinning
+      # an older image.tag.
+      path: /ready
       initialDelaySeconds: 1
       periodSeconds: 10
       timeoutSeconds: 5

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -93,9 +93,6 @@ hyperdx:
     resources: {}
     livenessProbe:
       enabled: true
-      # Liveness only checks the process is serving HTTP — it deliberately
-      # checks no external dependencies, since restarting the pod does not
-      # fix a dependency outage.
       path: /health
       initialDelaySeconds: 10
       periodSeconds: 30
@@ -103,10 +100,6 @@ hyperdx:
       failureThreshold: 3
     readinessProbe:
       enabled: true
-      # Mongo-aware readiness: /ready returns 503 until the API's MongoDB
-      # connection is established, so unready pods are removed from Service
-      # endpoints. Requires HyperDX >= 2.36.0 — set to /health when pinning
-      # an older image.tag.
       path: /ready
       initialDelaySeconds: 1
       periodSeconds: 10


### PR DESCRIPTION
## Why

hyperdxio/hyperdx#2966: an API pod that never established its MongoDB connection stayed `1/1 Running` for 30 hours because both chart probes hit `GET /health`, which returns 200 unconditionally. Every Mongo-backed request (including `/v1/opamp`) failed while Kubernetes kept routing traffic to the pod.

HyperDX 2.36.0 (hyperdxio/hyperdx#2968, included in this chart's current `appVersion`) adds `GET /ready`, which returns 503 until the MongoDB connection is established.

## What

- **Readiness probe defaults to `/ready`** — pods without a Mongo connection are now removed from Service endpoints instead of staying Ready.
- **Liveness probe stays on `/health`** — pure process-liveness; restarting a pod does not fix a Mongo outage, and the API now retries the connection internally.
- **Probe paths are configurable**: new `hyperdx.deployment.livenessProbe.path` and `hyperdx.deployment.readinessProbe.path` values, with template-level `| default` fallbacks so existing values files that override probe blocks without a `path` key still render correctly.

## Compatibility

Users pinning `hyperdx.deployment.image.tag` < 2.36.0 must set `readinessProbe.path: /health` — older images do not serve `/ready` and pods would never become Ready. Called out in the changeset and values.yaml comments.

## Testing

- `helm template` clean on default values, `examples/api-only`, and `examples/alb-ingress`
- `helm unittest charts/clickstack`: 193/193 passing, including updated default-path assertions and a new custom-probe-path test
