### PR TITLE
feat: roll HyperDX pods on config changes

### DIFF
--- a/.changeset/roll-hyperdx-on-config-changes.md
+++ b/.changeset/roll-hyperdx-on-config-changes.md
@@ -1,0 +1,5 @@
+---
+"helm-charts": minor
+---
+
+Automatically roll HyperDX pods when the chart-managed ConfigMap or Secret content changes. The first upgrade containing this change adds checksum annotations and triggers a one-time HyperDX rollout.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Helm template source must use LF so rendered-resource checksums are platform-independent.
+charts/clickstack/templates/** text eol=lf

--- a/charts/clickstack/templates/_helpers.tpl
+++ b/charts/clickstack/templates/_helpers.tpl
@@ -228,3 +228,41 @@ ClickHouse headless service name. The operator creates a headless service named 
 {{- define "clickstack.clickhouse.svc" -}}
 {{- printf "%s-clickhouse-headless" (include "clickstack.clickhouse.fullname" .) -}}
 {{- end }}
+
+{{/*
+Render the chart-managed HyperDX ConfigMap from one canonical template so the
+manifest and the Deployment rollout checksum cannot drift.
+*/}}
+{{- define "clickstack.hyperdx.configmap" -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clickstack-config
+  labels:
+    {{- include "clickstack.labels" . | nindent 4 }}
+data:
+  {{- range $k, $v := .Values.hyperdx.config }}
+  {{ $k }}: {{ tpl (toString $v) $ | quote }}
+  {{- end }}
+  {{- if and .Values.global.otelCollector.customConfig (not (hasKey .Values.hyperdx.config "CUSTOM_OTELCOL_CONFIG_FILE")) }}
+  CUSTOM_OTELCOL_CONFIG_FILE: "/etc/otelcol-contrib/custom/custom.config.yaml"
+  {{- end }}
+{{- end }}
+
+{{/*
+Render the chart-managed HyperDX Secret from one canonical template so the
+manifest and the Deployment rollout checksum cannot drift.
+*/}}
+{{- define "clickstack.hyperdx.secret" -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: clickstack-secret
+  labels:
+    {{- include "clickstack.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $k, $v := .Values.hyperdx.secrets }}
+  {{ $k }}: {{ tpl (toString $v) $ | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/clickstack/templates/hyperdx/configmap.yaml
+++ b/charts/clickstack/templates/hyperdx/configmap.yaml
@@ -1,13 +1,1 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: clickstack-config
-  labels:
-    {{- include "clickstack.labels" . | nindent 4 }}
-data:
-  {{- range $k, $v := .Values.hyperdx.config }}
-  {{ $k }}: {{ tpl (toString $v) $ | quote }}
-  {{- end }}
-  {{- if and .Values.global.otelCollector.customConfig (not (hasKey .Values.hyperdx.config "CUSTOM_OTELCOL_CONFIG_FILE")) }}
-  CUSTOM_OTELCOL_CONFIG_FILE: "/etc/otelcol-contrib/custom/custom.config.yaml"
-  {{- end }}
+{{- include "clickstack.hyperdx.configmap" . }}

--- a/charts/clickstack/templates/hyperdx/deployment.yaml
+++ b/charts/clickstack/templates/hyperdx/deployment.yaml
@@ -1,4 +1,8 @@
 {{- $podAnnotations := mergeOverwrite (dict) (default (dict) .Values.hyperdx.deployment.annotations) (default (dict) .Values.hyperdx.deployment.podAnnotations) -}}
+{{- $_ := set $podAnnotations "checksum/clickstack-config" (include "clickstack.hyperdx.configmap" . | sha256sum) -}}
+{{- if ne .Values.hyperdx.secrets nil -}}
+{{- $_ := set $podAnnotations "checksum/clickstack-secret" (include "clickstack.hyperdx.secret" . | sha256sum) -}}
+{{- end -}}
 {{- $dashboards := default (dict) .Values.hyperdx.dashboards -}}
 {{- include "clickstack.hyperdx.validateDashboards" . -}}
 apiVersion: apps/v1

--- a/charts/clickstack/templates/hyperdx/deployment.yaml
+++ b/charts/clickstack/templates/hyperdx/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $podAnnotations := mergeOverwrite (dict) (default (dict) .Values.hyperdx.deployment.annotations) (default (dict) .Values.hyperdx.deployment.podAnnotations) -}}
-{{- $_ := set $podAnnotations "checksum/clickstack-config" (include "clickstack.hyperdx.configmap" . | sha256sum) -}}
+{{- $_ := set $podAnnotations "checksum/clickstack-config" (include "clickstack.hyperdx.configmap" . | replace "\r\n" "\n" | sha256sum) -}}
 {{- if ne .Values.hyperdx.secrets nil -}}
-{{- $_ := set $podAnnotations "checksum/clickstack-secret" (include "clickstack.hyperdx.secret" . | sha256sum) -}}
+{{- $_ := set $podAnnotations "checksum/clickstack-secret" (include "clickstack.hyperdx.secret" . | replace "\r\n" "\n" | sha256sum) -}}
 {{- end -}}
 {{- $dashboards := default (dict) .Values.hyperdx.dashboards -}}
 {{- include "clickstack.hyperdx.validateDashboards" . -}}

--- a/charts/clickstack/templates/hyperdx/deployment.yaml
+++ b/charts/clickstack/templates/hyperdx/deployment.yaml
@@ -1,7 +1,7 @@
 {{- $podAnnotations := mergeOverwrite (dict) (default (dict) .Values.hyperdx.deployment.annotations) (default (dict) .Values.hyperdx.deployment.podAnnotations) -}}
-{{- $_ := set $podAnnotations "checksum/clickstack-config" (include "clickstack.hyperdx.configmap" . | replace "\r\n" "\n" | sha256sum) -}}
+{{- $_ := set $podAnnotations "checksum/clickstack-config" (include "clickstack.hyperdx.configmap" . | sha256sum) -}}
 {{- if ne .Values.hyperdx.secrets nil -}}
-{{- $_ := set $podAnnotations "checksum/clickstack-secret" (include "clickstack.hyperdx.secret" . | replace "\r\n" "\n" | sha256sum) -}}
+{{- $_ := set $podAnnotations "checksum/clickstack-secret" (include "clickstack.hyperdx.secret" . | sha256sum) -}}
 {{- end -}}
 {{- $dashboards := default (dict) .Values.hyperdx.dashboards -}}
 {{- include "clickstack.hyperdx.validateDashboards" . -}}

--- a/charts/clickstack/templates/hyperdx/secret.yaml
+++ b/charts/clickstack/templates/hyperdx/secret.yaml
@@ -2,15 +2,5 @@
 {{- fail "hyperdx.secrets cannot be null when mongodb, clickhouse, or otel-collector is enabled -- these subcharts require the clickstack-secret for credentials" }}
 {{- end }}
 {{- if ne .Values.hyperdx.secrets nil }}
-apiVersion: v1
-kind: Secret
-metadata:
-  name: clickstack-secret
-  labels:
-    {{- include "clickstack.labels" . | nindent 4 }}
-type: Opaque
-stringData:
-  {{- range $k, $v := .Values.hyperdx.secrets }}
-  {{ $k }}: {{ tpl (toString $v) $ | quote }}
-  {{- end }}
+{{- include "clickstack.hyperdx.secret" . }}
 {{- end }}

--- a/charts/clickstack/tests/hyperdx-rollout-checksums_test.yaml
+++ b/charts/clickstack/tests/hyperdx-rollout-checksums_test.yaml
@@ -1,0 +1,129 @@
+suite: Test HyperDX Rollout Checksums
+templates:
+  - hyperdx/deployment.yaml
+  - hyperdx/configmap.yaml
+  - hyperdx/secret.yaml
+# Pin chart metadata so release version bumps do not invalidate content-change assertions.
+chart:
+  version: 3.3.0
+  appVersion: 2.36.0
+tests:
+  - it: should render deterministic checksums for chart-managed configuration
+    template: hyperdx/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["checksum/clickstack-config"]
+          value: 0587572216112d61fd7d298001d71ed852194038be79415116a447e260753058
+      - equal:
+          path: spec.template.metadata.annotations["checksum/clickstack-secret"]
+          value: 7d047b36293876f9242bce55bbd3ce9a255e51a425934a7cea4f2ab04f86895d
+
+  - it: should change only the ConfigMap checksum when config content changes
+    template: hyperdx/deployment.yaml
+    set:
+      hyperdx:
+        config:
+          FRONTEND_URL: https://changed.example
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["checksum/clickstack-config"]
+          value: 8149416c5dff3a76c98e11c8f1fef4ab3a6eca7cd68e79d6a1bd956c196499a3
+      - equal:
+          path: spec.template.metadata.annotations["checksum/clickstack-secret"]
+          value: 7d047b36293876f9242bce55bbd3ce9a255e51a425934a7cea4f2ab04f86895d
+
+  - it: should change only the Secret checksum when independent secret content changes
+    template: hyperdx/deployment.yaml
+    set:
+      hyperdx:
+        secrets:
+          HYPERDX_API_KEY: changed
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["checksum/clickstack-config"]
+          value: 0587572216112d61fd7d298001d71ed852194038be79415116a447e260753058
+      - equal:
+          path: spec.template.metadata.annotations["checksum/clickstack-secret"]
+          value: a94315e89cfbbe97c9d0f11a48fa845d1f324473ee64666032c9151ffb3a4349
+
+  - it: should omit the Secret checksum when using external secrets
+    template: hyperdx/deployment.yaml
+    set:
+      mongodb:
+        enabled: false
+      clickhouse:
+        enabled: false
+      otel-collector:
+        enabled: false
+      hyperdx:
+        secrets: null
+        config:
+          MONGO_URI: mongodb://external
+        deployment:
+          env:
+            - name: HYPERDX_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: external-hyperdx
+                  key: api-key
+    asserts:
+      - matchRegex:
+          path: spec.template.metadata.annotations["checksum/clickstack-config"]
+          pattern: ^[a-f0-9]{64}$
+      - notExists:
+          path: spec.template.metadata.annotations["checksum/clickstack-secret"]
+      - notExists:
+          path: spec.template.spec.containers[0].envFrom[1]
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HYPERDX_API_KEY
+            valueFrom:
+              secretKeyRef:
+                name: external-hyperdx
+                key: api-key
+
+  - it: should preserve user annotations while reserving generated checksum keys
+    template: hyperdx/deployment.yaml
+    set:
+      hyperdx:
+        deployment:
+          annotations:
+            example.com/legacy: preserved
+          podAnnotations:
+            example.com/pod: preserved
+            checksum/clickstack-config: caller-value
+            checksum/clickstack-secret: caller-value
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["example.com/legacy"]
+          value: preserved
+      - equal:
+          path: spec.template.metadata.annotations["example.com/pod"]
+          value: preserved
+      - equal:
+          path: spec.template.metadata.annotations["checksum/clickstack-config"]
+          value: 0587572216112d61fd7d298001d71ed852194038be79415116a447e260753058
+      - equal:
+          path: spec.template.metadata.annotations["checksum/clickstack-secret"]
+          value: 7d047b36293876f9242bce55bbd3ce9a255e51a425934a7cea4f2ab04f86895d
+      - notEqual:
+          path: spec.template.metadata.annotations["checksum/clickstack-config"]
+          value: caller-value
+      - notEqual:
+          path: spec.template.metadata.annotations["checksum/clickstack-secret"]
+          value: caller-value
+
+  - it: should keep checksums stable when unrelated values change
+    template: hyperdx/deployment.yaml
+    set:
+      hyperdx:
+        deployment:
+          replicas: 3
+    asserts:
+      - equal:
+          path: spec.template.metadata.annotations["checksum/clickstack-config"]
+          value: 0587572216112d61fd7d298001d71ed852194038be79415116a447e260753058
+      - equal:
+          path: spec.template.metadata.annotations["checksum/clickstack-secret"]
+          value: 7d047b36293876f9242bce55bbd3ce9a255e51a425934a7cea4f2ab04f86895d

--- a/charts/clickstack/tests/hyperdx-rollout-checksums_test.yaml
+++ b/charts/clickstack/tests/hyperdx-rollout-checksums_test.yaml
@@ -13,10 +13,10 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-config"]
-          value: 0587572216112d61fd7d298001d71ed852194038be79415116a447e260753058
+          value: b76d0e7c9c3bc42636d77be4768074ac0627ebf8af4c5f75caa5ce697e7e04fe
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-secret"]
-          value: 7d047b36293876f9242bce55bbd3ce9a255e51a425934a7cea4f2ab04f86895d
+          value: dc97804d86c9e1c30f568e66a03cd377f12e0a2debeb24306c8a644013f03e52
 
   - it: should change only the ConfigMap checksum when config content changes
     template: hyperdx/deployment.yaml
@@ -27,10 +27,10 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-config"]
-          value: 8149416c5dff3a76c98e11c8f1fef4ab3a6eca7cd68e79d6a1bd956c196499a3
+          value: 5e3f3ae827e5f86b4fa72e341fc599e3b25d66e7d0ef2927f45cbd99b7cfbd16
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-secret"]
-          value: 7d047b36293876f9242bce55bbd3ce9a255e51a425934a7cea4f2ab04f86895d
+          value: dc97804d86c9e1c30f568e66a03cd377f12e0a2debeb24306c8a644013f03e52
 
   - it: should change only the Secret checksum when independent secret content changes
     template: hyperdx/deployment.yaml
@@ -41,10 +41,10 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-config"]
-          value: 0587572216112d61fd7d298001d71ed852194038be79415116a447e260753058
+          value: b76d0e7c9c3bc42636d77be4768074ac0627ebf8af4c5f75caa5ce697e7e04fe
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-secret"]
-          value: a94315e89cfbbe97c9d0f11a48fa845d1f324473ee64666032c9151ffb3a4349
+          value: 55205540ae9ba37fa6d226bcbccf8a7c5d039e0724ea12a4f7044af2b9d37eff
 
   - it: should omit the Secret checksum when using external secrets
     template: hyperdx/deployment.yaml
@@ -103,10 +103,10 @@ tests:
           value: preserved
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-config"]
-          value: 0587572216112d61fd7d298001d71ed852194038be79415116a447e260753058
+          value: b76d0e7c9c3bc42636d77be4768074ac0627ebf8af4c5f75caa5ce697e7e04fe
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-secret"]
-          value: 7d047b36293876f9242bce55bbd3ce9a255e51a425934a7cea4f2ab04f86895d
+          value: dc97804d86c9e1c30f568e66a03cd377f12e0a2debeb24306c8a644013f03e52
       - notEqual:
           path: spec.template.metadata.annotations["checksum/clickstack-config"]
           value: caller-value
@@ -123,7 +123,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-config"]
-          value: 0587572216112d61fd7d298001d71ed852194038be79415116a447e260753058
+          value: b76d0e7c9c3bc42636d77be4768074ac0627ebf8af4c5f75caa5ce697e7e04fe
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-secret"]
-          value: 7d047b36293876f9242bce55bbd3ce9a255e51a425934a7cea4f2ab04f86895d
+          value: dc97804d86c9e1c30f568e66a03cd377f12e0a2debeb24306c8a644013f03e52

--- a/charts/clickstack/tests/hyperdx-rollout-checksums_test.yaml
+++ b/charts/clickstack/tests/hyperdx-rollout-checksums_test.yaml
@@ -7,16 +7,21 @@ templates:
 chart:
   version: 3.3.0
   appVersion: 2.36.0
+release:
+  name: checksum-test
+  namespace: checksum-test
+  revision: 1
+  upgrade: true
 tests:
   - it: should render deterministic checksums for chart-managed configuration
     template: hyperdx/deployment.yaml
     asserts:
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-config"]
-          value: b76d0e7c9c3bc42636d77be4768074ac0627ebf8af4c5f75caa5ce697e7e04fe
+          value: 5684d7349035a2d436775b5e0b5033c204ae8f05c70ff0d3a8cea191c3cfa4ab
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-secret"]
-          value: dc97804d86c9e1c30f568e66a03cd377f12e0a2debeb24306c8a644013f03e52
+          value: 93200c574b88c22d434ac7d53d4f1105effa8d491a41f9102e131b7f5b919218
 
   - it: should change only the ConfigMap checksum when config content changes
     template: hyperdx/deployment.yaml
@@ -27,10 +32,10 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-config"]
-          value: 5e3f3ae827e5f86b4fa72e341fc599e3b25d66e7d0ef2927f45cbd99b7cfbd16
+          value: c43e9bf82686f182834f1ce175f60f07f508d26520ef7ed6147be973c6d6e01e
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-secret"]
-          value: dc97804d86c9e1c30f568e66a03cd377f12e0a2debeb24306c8a644013f03e52
+          value: 93200c574b88c22d434ac7d53d4f1105effa8d491a41f9102e131b7f5b919218
 
   - it: should change only the Secret checksum when independent secret content changes
     template: hyperdx/deployment.yaml
@@ -41,10 +46,10 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-config"]
-          value: b76d0e7c9c3bc42636d77be4768074ac0627ebf8af4c5f75caa5ce697e7e04fe
+          value: 5684d7349035a2d436775b5e0b5033c204ae8f05c70ff0d3a8cea191c3cfa4ab
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-secret"]
-          value: 55205540ae9ba37fa6d226bcbccf8a7c5d039e0724ea12a4f7044af2b9d37eff
+          value: 1adcdfb26c7114f9990031b28eb1ae1d7097dcf27c16487d16c8666da062a507
 
   - it: should omit the Secret checksum when using external secrets
     template: hyperdx/deployment.yaml
@@ -103,10 +108,10 @@ tests:
           value: preserved
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-config"]
-          value: b76d0e7c9c3bc42636d77be4768074ac0627ebf8af4c5f75caa5ce697e7e04fe
+          value: 5684d7349035a2d436775b5e0b5033c204ae8f05c70ff0d3a8cea191c3cfa4ab
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-secret"]
-          value: dc97804d86c9e1c30f568e66a03cd377f12e0a2debeb24306c8a644013f03e52
+          value: 93200c574b88c22d434ac7d53d4f1105effa8d491a41f9102e131b7f5b919218
       - notEqual:
           path: spec.template.metadata.annotations["checksum/clickstack-config"]
           value: caller-value
@@ -123,7 +128,7 @@ tests:
     asserts:
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-config"]
-          value: b76d0e7c9c3bc42636d77be4768074ac0627ebf8af4c5f75caa5ce697e7e04fe
+          value: 5684d7349035a2d436775b5e0b5033c204ae8f05c70ff0d3a8cea191c3cfa4ab
       - equal:
           path: spec.template.metadata.annotations["checksum/clickstack-secret"]
-          value: dc97804d86c9e1c30f568e66a03cd377f12e0a2debeb24306c8a644013f03e52
+          value: 93200c574b88c22d434ac7d53d4f1105effa8d491a41f9102e131b7f5b919218

--- a/charts/clickstack/values.yaml
+++ b/charts/clickstack/values.yaml
@@ -100,6 +100,7 @@ hyperdx:
   # Shared non-sensitive environment variables. Used by HyperDX and OTEL collector via envFrom.
   # All values support Helm template expressions (rendered via tpl).
   # Override any entry with a plain string to point at an external service.
+  # Changes to the rendered ConfigMap automatically roll the HyperDX Deployment.
   config:
     APP_PORT: "3000"
     API_PORT: "8000"
@@ -140,6 +141,9 @@ hyperdx:
   # managing secrets externally via deployment.env valueFrom entries. Requires
   # mongodb, clickhouse, and otel-collector to all be disabled. Users must
   # provide all required environment variables through their own secret management.
+  # Changes to this chart-managed Secret automatically roll the HyperDX Deployment.
+  # External Secret changes require an explicit rollout because Helm cannot hash
+  # resources that are not rendered by this chart.
   secrets:
     HYPERDX_API_KEY: "xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
     CLICKHOUSE_PASSWORD: "otelcollectorpass"
@@ -175,6 +179,8 @@ hyperdx:
     # Annotations applied to the HyperDX Deployment metadata.
     deploymentAnnotations: {}
     # Annotations applied to the HyperDX pod template metadata.
+    # checksum/clickstack-config and checksum/clickstack-secret are reserved for
+    # chart-generated rollout checksums and cannot be overridden.
     podAnnotations: {}
     # Deprecated: use podAnnotations. Retained for backward compatibility;
     # podAnnotations takes precedence when both maps contain the same key.


### PR DESCRIPTION
## Summary

- add chart-owned pod-template checksums for the rendered HyperDX ConfigMap and optional Secret
- preserve existing user annotation merge precedence while reserving scoped checksum keys
- document automatic rollout behavior and external Secret limitations
- add focused Helm unit coverage for deterministic, content-sensitive checksums

## Motivation

HyperDX consumes `clickstack-config` and `clickstack-secret` through `envFrom`. Kubernetes resolves those environment variables when a pod starts, so changing only the ConfigMap or Secret during `helm upgrade` leaves existing HyperDX pods with stale startup configuration unless the Deployment pod template also changes.

This follows Helm's documented `include ... | sha256sum` rollout pattern. The ConfigMap and Secret manifests now share canonical named renderers with the Deployment checksums, ensuring the hashed content cannot drift from the resources Helm applies. Git enforces LF for ClickStack Helm template source, so the standard `include ... | sha256sum` pattern produces identical annotations across checkout platforms without runtime normalization.

No new values API is needed: these are chart-managed resources with deterministic rollout behavior. Arbitrary template paths or `tpl` evaluation in user values would be less safe and would not improve this owned-resource case.

## Backward compatibility

Existing `hyperdx.deployment.annotations` and `hyperdx.deployment.podAnnotations` values remain merged with the same precedence. The generated `checksum/clickstack-config` and `checksum/clickstack-secret` keys are chart-reserved and override caller values so stale hashes cannot disable rollouts.

`checksum/clickstack-secret` is omitted when `hyperdx.secrets: null`, matching Secret rendering and `envFrom` behavior. Externally managed Secret changes still require an explicit rollout because Helm cannot hash resources it does not render.

The first upgrade containing this change intentionally performs a one-time HyperDX rollout because the generated annotations are added to the pod template. The checksum covers the full rendered chart-managed resource, including standard chart labels, so a chart-version-only upgrade also intentionally rolls HyperDX; this matches Helm's documented rendered-template checksum pattern.

## Tests

Verified with the repository-pinned `helm-unittest` plugin v1.0.3:

- `helm unittest --strict -f tests/hyperdx-rollout-checksums_test.yaml charts/clickstack` — 6 tests passed
- `helm unittest charts/clickstack` — 31 suites, 257 tests passed
- repeated identical `helm template` renders produce identical checksum annotations
- config-only and secret-only changes alter only their corresponding checksum; unrelated Deployment values leave both stable
- `helm lint --strict charts/clickstack`
- default chart render
- ALB ingress, API-only, and OTEL custom-config example renders
- `git diff --check`